### PR TITLE
Put kotlin-stdlib to compile scope

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -45,7 +45,7 @@ subprojects {
     testCompile "org.mockito:mockito-core:$mockitoVersion"
     testCompile "io.kotlintest:kotlintest:$kotlinTestVersion"
     testCompile "com.nhaarman:mockito-kotlin:$kotlinMockitoVersion"
-    testCompile "org.jetbrains.kotlin:kotlin-stdlib:$kotlinVersion"
+    compile "org.jetbrains.kotlin:kotlin-stdlib:$kotlinVersion"
   }
 
   jar {


### PR DESCRIPTION
If I'm not mistaken, one should only use `testCompile` scope for the libraries that are only useful in tests.

(Admittedly I changed this as a workaround because Intellij expected it. But after thinking twice I consider it reasonable)

This is pretty trivial so I didn't doc it.