### PR TITLE
Collection operations for gdx collections

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 #### 1.9.6-SNAPSHOT
 
+- **[FEATURE]** (`ktx-collections`) Added `map`, `filter` and `flatten` that return LibGDX collections.
 - **[FEATURE]** (`ktx-app`) Added `KtxGame`: **KTX** equivalent of LibGDX `Game`.
 - **[FEATURE]** (`ktx-app`) Added `KtxScreen`: adapter of the LibGDX `Screen` interface making all methods optional to implement.
 - **[FEATURE]** (`ktx-app`) Added `emptyScreen` utility method returning a no-op implementation of `Screen`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 #### 1.9.6-SNAPSHOT
 
-- **[FEATURE]** (`ktx-collections`) Added `map`, `filter` and `flatten` that return LibGDX collections.
+- **[FEATURE]** (`ktx-collections`) Added `map`, `filter` and `flatten` extension methods that return LibGDX collections.
 - **[FEATURE]** (`ktx-app`) Added `KtxGame`: **KTX** equivalent of LibGDX `Game`.
 - **[FEATURE]** (`ktx-app`) Added `KtxScreen`: adapter of the LibGDX `Screen` interface making all methods optional to implement.
 - **[FEATURE]** (`ktx-app`) Added `emptyScreen` utility method returning a no-op implementation of `Screen`.

--- a/build.gradle
+++ b/build.gradle
@@ -47,7 +47,7 @@ subprojects {
     testCompile "org.mockito:mockito-core:$mockitoVersion"
     testCompile "io.kotlintest:kotlintest:$kotlinTestVersion"
     testCompile "com.nhaarman:mockito-kotlin:$kotlinMockitoVersion"
-    compile "org.jetbrains.kotlin:kotlin-stdlib:$kotlinVersion"
+    testCompile "org.jetbrains.kotlin:kotlin-stdlib:$kotlinVersion"
   }
 
   jar {

--- a/build.gradle
+++ b/build.gradle
@@ -47,7 +47,7 @@ subprojects {
     testCompile "org.mockito:mockito-core:$mockitoVersion"
     testCompile "io.kotlintest:kotlintest:$kotlinTestVersion"
     testCompile "com.nhaarman:mockito-kotlin:$kotlinMockitoVersion"
-    testCompile "org.jetbrains.kotlin:kotlin-stdlib:$kotlinVersion"
+    compile "org.jetbrains.kotlin:kotlin-stdlib:$kotlinVersion"
   }
 
   jar {

--- a/collections/README.md
+++ b/collections/README.md
@@ -32,6 +32,7 @@ chained.
 - Missing `addAll` and `removeAll` methods for arrays and iterables were added.
 - `iterate` method allows to iterate over collection's elements, while providing reference to `MutableInterator`. Can be
 used to easily remove collection elements during iteration.
+- `map`, `filter`, `flatten` and `flatMap` methods that work like methods in Kotlin stdlib but return `GdxArray`.
 - Every iterable and array can be converted to `Array` using `toGdxArray` method.
 - `IntArray`, `BooleanArray` and `FloatArray` can be converted to corresponding LibGDX primitive collections using
 `toGdxArray` method.
@@ -57,6 +58,7 @@ chained.
 - Missing `addAll` and `removeAll` methods for arrays and iterables were added.
 - `iterate` method allows to iterate over collection's elements, while providing reference to `MutableIterator`. Can be
 used to easily remove collection elements during iteration.
+- `map`, `filter`, `flatten` and `flatMap` methods that work like methods in Kotlin stdlib but return `GdxSet`.
 - Every iterable and array can be converted to `ObjectSet` using `toGdxSet` method.
 - `IntArray` can be converted to `IntSet` using `toGdxSet` method.
 - Type alias added for consistency with other collections: `GdxSet` - `com.badlogic.gdx.utils.ObjectSet`.
@@ -75,6 +77,7 @@ if the variable is a possible null.
 `map.put(key, value)`.
 - `iterate` method allows to iterate over map elements with a reference to `MutableIterator`. Can be used to easily
 remove elements from the map.
+- `map`, `filter`, `flatten` and `flatMap` methods that work like methods in Kotlin stdlib but return `GdxMap` and `GdxArray`.
 - Keys stored in the map can be quickly converted to an `ObjectSet` using `toGdxSet` method.
 - Every iterable and array can be converted to `ObjectMap` using `toGdxMap` method. A lambda that converts values to keys
 has to be provided - since the method is inlined, no new lambda object will be created at runtime.

--- a/collections/src/main/kotlin/ktx/collections/arrays.kt
+++ b/collections/src/main/kotlin/ktx/collections/arrays.kt
@@ -227,7 +227,6 @@ inline fun <Type, R : Comparable<R>> GdxArray<out Type>.sortByDescending(crossin
   if (size > 1) this.sort(compareByDescending(selector))
 }
 
-
 /**
  * Returns a [GdxArray] containing the results of applying the given [transform] function
  * to each element in the original [GdxArray].
@@ -239,7 +238,6 @@ inline fun <Type, R> GdxArray<Type>.map(transform: (Type) -> R): GdxArray<R> {
   }
   return destination
 }
-
 
 /**
  * Returns a [GdxArray] containing only elements matching the given [predicate].
@@ -254,7 +252,6 @@ inline fun <Type> GdxArray<Type>.filter(predicate: (Type) -> Boolean): GdxArray<
   return destination
 }
 
-
 /**
  * Returns a single [GdxArray] of all elements from all collections in the given [GdxArray].
  */
@@ -266,7 +263,6 @@ inline fun <Type, C: Iterable<Type>> GdxArray<out C>.flatten(): GdxArray<Type> {
   return destination
 }
 
-
 /**
  * Returns a single [GdxArray] of all elements yielded from results of transform function being invoked
  * on each entry of original [GdxArray].
@@ -274,7 +270,6 @@ inline fun <Type, C: Iterable<Type>> GdxArray<out C>.flatten(): GdxArray<Type> {
 inline fun <Type, R> GdxArray<Type>.flatMap(transform: (Type) -> Iterable<R>): GdxArray<R> {
   return this.map(transform).flatten()
 }
-
 
 /**
  * @param initialCapacity initial capacity of the set. Will be resized if necessary. Defaults to array size.

--- a/collections/src/main/kotlin/ktx/collections/arrays.kt
+++ b/collections/src/main/kotlin/ktx/collections/arrays.kt
@@ -1,4 +1,4 @@
-@file:Suppress("NOTHING_TO_INLINE")
+@file:Suppress("NOTHING_TO_INLINE", "LoopToCallChain")
 
 package ktx.collections
 
@@ -226,6 +226,55 @@ inline fun <Type, R : Comparable<R>> GdxArray<out Type>.sortBy(crossinline selec
 inline fun <Type, R : Comparable<R>> GdxArray<out Type>.sortByDescending(crossinline selector: (Type) -> R?): Unit {
   if (size > 1) this.sort(compareByDescending(selector))
 }
+
+
+/**
+ * Returns a [GdxArray] containing the results of applying the given [transform] function
+ * to each element in the original [GdxArray].
+ */
+inline fun <Type, R> GdxArray<Type>.map(transform: (Type) -> R): GdxArray<R> {
+  val destination = GdxArray<R>(this.size)
+  for(item in this) {
+    destination.add(transform(item))
+  }
+  return destination
+}
+
+
+/**
+ * Returns a [GdxArray] containing only elements matching the given [predicate].
+ */
+inline fun <Type> GdxArray<Type>.filter(predicate: (Type) -> Boolean): GdxArray<Type> {
+  val destination = GdxArray<Type>()
+  for(item in this) {
+    if(predicate(item)) {
+      destination.add(item)
+    }
+  }
+  return destination
+}
+
+
+/**
+ * Returns a single [GdxArray] of all elements from all collections in the given [GdxArray].
+ */
+inline fun <Type, C: Iterable<Type>> GdxArray<out C>.flatten(): GdxArray<Type> {
+  val destination = GdxArray<Type>()
+  for(item in this) {
+      destination.addAll(item)
+  }
+  return destination
+}
+
+
+/**
+ * Returns a single [GdxArray] of all elements yielded from results of transform function being invoked
+ * on each entry of original [GdxArray].
+ */
+inline fun <Type, R> GdxArray<Type>.flatMap(transform: (Type) -> Iterable<R>): GdxArray<R> {
+  return this.map(transform).flatten()
+}
+
 
 /**
  * @param initialCapacity initial capacity of the set. Will be resized if necessary. Defaults to array size.

--- a/collections/src/main/kotlin/ktx/collections/arrays.kt
+++ b/collections/src/main/kotlin/ktx/collections/arrays.kt
@@ -233,7 +233,7 @@ inline fun <Type, R : Comparable<R>> GdxArray<out Type>.sortByDescending(crossin
  */
 inline fun <Type, R> GdxArray<Type>.map(transform: (Type) -> R): GdxArray<R> {
   val destination = GdxArray<R>(this.size)
-  for(item in this) {
+  for (item in this) {
     destination.add(transform(item))
   }
   return destination
@@ -244,8 +244,8 @@ inline fun <Type, R> GdxArray<Type>.map(transform: (Type) -> R): GdxArray<R> {
  */
 inline fun <Type> GdxArray<Type>.filter(predicate: (Type) -> Boolean): GdxArray<Type> {
   val destination = GdxArray<Type>()
-  for(item in this) {
-    if(predicate(item)) {
+  for (item in this) {
+    if (predicate(item)) {
       destination.add(item)
     }
   }
@@ -255,10 +255,10 @@ inline fun <Type> GdxArray<Type>.filter(predicate: (Type) -> Boolean): GdxArray<
 /**
  * Returns a single [GdxArray] of all elements from all collections in the given [GdxArray].
  */
-inline fun <Type, C: Iterable<Type>> GdxArray<out C>.flatten(): GdxArray<Type> {
+inline fun <Type, C : Iterable<Type>> GdxArray<out C>.flatten(): GdxArray<Type> {
   val destination = GdxArray<Type>()
-  for(item in this) {
-      destination.addAll(item)
+  for (item in this) {
+    destination.addAll(item)
   }
   return destination
 }

--- a/collections/src/main/kotlin/ktx/collections/lists.kt
+++ b/collections/src/main/kotlin/ktx/collections/lists.kt
@@ -229,7 +229,7 @@ class PooledList<T>(val nodePool: Pool<Node<T>>) : Iterable<T> {
    */
   inline fun <R> map(transform: (T) -> R): GdxList<R> {
     val destination = gdxListOf<R>()
-    for(item in this) {
+    for (item in this) {
       destination.add(transform(item))
     }
     return destination
@@ -240,8 +240,8 @@ class PooledList<T>(val nodePool: Pool<Node<T>>) : Iterable<T> {
    */
   inline fun filter(predicate: (T) -> Boolean): GdxList<T> {
     val destination = gdxListOf<T>()
-    for(item in this) {
-      if(predicate(item)) {
+    for (item in this) {
+      if (predicate(item)) {
         destination.add(item)
       }
     }
@@ -360,9 +360,9 @@ class PooledList<T>(val nodePool: Pool<Node<T>>) : Iterable<T> {
 /**
  * Returns a single [GdxList] of all elements from all collections in the given [GdxList].
  */
-inline fun <Type, C: Iterable<Type>> GdxList<out C>.flatten(): GdxList<Type> {
+inline fun <Type, C : Iterable<Type>> GdxList<out C>.flatten(): GdxList<Type> {
   val destination = gdxListOf<Type>()
-  for(item in this) {
+  for (item in this) {
     destination.addAll(item)
   }
   return destination

--- a/collections/src/main/kotlin/ktx/collections/lists.kt
+++ b/collections/src/main/kotlin/ktx/collections/lists.kt
@@ -1,3 +1,5 @@
+@file:Suppress("LoopToCallChain", "NOTHING_TO_INLINE")
+
 package ktx.collections
 
 import com.badlogic.gdx.utils.Pool
@@ -220,6 +222,41 @@ class PooledList<T>(val nodePool: Pool<Node<T>>) : Iterable<T> {
     size = 0
   }
 
+
+  /**
+   * Returns a [GdxList] containing the results of applying the given [transform] function
+   * to each element in the original [GdxList].
+   */
+  inline fun <R> map(transform: (T) -> R): GdxList<R> {
+    val destination = gdxListOf<R>()
+    for(item in this) {
+      destination.add(transform(item))
+    }
+    return destination
+  }
+
+  /**
+   * Returns a [GdxList] containing only elements matching the given [predicate].
+   */
+  inline fun filter(predicate: (T) -> Boolean): GdxList<T> {
+    val destination = gdxListOf<T>()
+    for(item in this) {
+      if(predicate(item)) {
+        destination.add(item)
+      }
+    }
+    return destination
+  }
+
+  /**
+   * Returns a single [GdxList] of all elements yielded from results of transform function being invoked
+   * on each entry of original [GdxList].
+   */
+  inline fun <R> flatMap(transform: (T) -> Iterable<R>): GdxList<R> {
+    return this.map(transform).flatten()
+  }
+
+
   override fun toString(): String {
     return buildString {
       append("[")
@@ -318,6 +355,17 @@ class PooledList<T>(val nodePool: Pool<Node<T>>) : Iterable<T> {
     size--
     return element!!
   }
+}
+
+/**
+ * Returns a single [GdxList] of all elements from all collections in the given [GdxList].
+ */
+inline fun <Type, C: Iterable<Type>> GdxList<out C>.flatten(): GdxList<Type> {
+  val destination = gdxListOf<Type>()
+  for(item in this) {
+    destination.addAll(item)
+  }
+  return destination
 }
 
 /**

--- a/collections/src/main/kotlin/ktx/collections/maps.kt
+++ b/collections/src/main/kotlin/ktx/collections/maps.kt
@@ -362,7 +362,7 @@ inline operator fun <Value> ObjectIntMap.Entry<Value>.component2() = value
  */
 inline fun <Key, Value, R> GdxMap<Key, Value>.map(transform: (Entry<Key, Value>) -> R): GdxMap<Key, R> {
   val destination = GdxMap<Key, R>(this.size)
-  for(item in this) {
+  for (item in this) {
     destination[item.key] = transform(item)
   }
   return destination
@@ -373,8 +373,8 @@ inline fun <Key, Value, R> GdxMap<Key, Value>.map(transform: (Entry<Key, Value>)
  */
 inline fun <Key, Value> GdxMap<Key, Value>.filter(predicate: (Entry<Key, Value>) -> Boolean): GdxMap<Key, Value> {
   val destination = GdxMap<Key, Value>()
-  for(item in this) {
-    if(predicate(item)) {
+  for (item in this) {
+    if (predicate(item)) {
       destination[item.key] = item.value
     }
   }
@@ -384,9 +384,9 @@ inline fun <Key, Value> GdxMap<Key, Value>.filter(predicate: (Entry<Key, Value>)
 /**
  * Returns a single [GdxArray] of all elements from all collections in the given [GdxMap].
  */
-inline fun <Key, Type, Value: Iterable<Type>> GdxMap<Key, out Value>.flatten(): GdxArray<Type> {
+inline fun <Key, Type, Value : Iterable<Type>> GdxMap<Key, out Value>.flatten(): GdxArray<Type> {
   val destination = GdxArray<Type>()
-  for(item in this) {
+  for (item in this) {
     destination.addAll(item.value)
   }
   return destination

--- a/collections/src/main/kotlin/ktx/collections/maps.kt
+++ b/collections/src/main/kotlin/ktx/collections/maps.kt
@@ -356,7 +356,6 @@ inline operator fun <Value> ObjectIntMap.Entry<Value>.component1() = key!!
  */
 inline operator fun <Value> ObjectIntMap.Entry<Value>.component2() = value
 
-
 /**
  * Returns a [GdxMap] containing the results of applying the given [transform] function
  * to each entry in the original [GdxMap].
@@ -368,7 +367,6 @@ inline fun <Key, Value, R> GdxMap<Key, Value>.map(transform: (Entry<Key, Value>)
   }
   return destination
 }
-
 
 /**
  * Returns a [GdxMap] containing only entries matching the given [predicate].
@@ -383,7 +381,6 @@ inline fun <Key, Value> GdxMap<Key, Value>.filter(predicate: (Entry<Key, Value>)
   return destination
 }
 
-
 /**
  * Returns a single [GdxArray] of all elements from all collections in the given [GdxMap].
  */
@@ -394,7 +391,6 @@ inline fun <Key, Type, Value: Iterable<Type>> GdxMap<Key, out Value>.flatten(): 
   }
   return destination
 }
-
 
 /**
  * Returns a single [GdxArray] of all elements yielded from results of transform function being invoked

--- a/collections/src/main/kotlin/ktx/collections/maps.kt
+++ b/collections/src/main/kotlin/ktx/collections/maps.kt
@@ -394,7 +394,7 @@ inline fun <Key, Type, Value: Iterable<Type>> GdxMap<Key, out Value>.flatten(): 
 
 /**
  * Returns a single [GdxArray] of all elements yielded from results of transform function being invoked
- * on each entry of original [GdxArray].
+ * on each entry of original [GdxMap].
  */
 inline fun <Key, Value, R> GdxMap<Key, Value>.flatMap(transform: (Entry<Key, Value>) -> Iterable<R>): GdxArray<R> {
   return this.map(transform).flatten()

--- a/collections/src/main/kotlin/ktx/collections/maps.kt
+++ b/collections/src/main/kotlin/ktx/collections/maps.kt
@@ -1,4 +1,4 @@
-@file:Suppress("NOTHING_TO_INLINE")
+@file:Suppress("NOTHING_TO_INLINE", "LoopToCallChain")
 
 package ktx.collections
 
@@ -355,3 +355,51 @@ inline operator fun <Value> ObjectIntMap.Entry<Value>.component1() = key!!
  * @return [ObjectIntMap.Entry.value]
  */
 inline operator fun <Value> ObjectIntMap.Entry<Value>.component2() = value
+
+
+/**
+ * Returns a [GdxMap] containing the results of applying the given [transform] function
+ * to each entry in the original [GdxMap].
+ */
+inline fun <Key, Value, R> GdxMap<Key, Value>.map(transform: (Entry<Key, Value>) -> R): GdxMap<Key, R> {
+  val destination = GdxMap<Key, R>(this.size)
+  for(item in this) {
+    destination[item.key] = transform(item)
+  }
+  return destination
+}
+
+
+/**
+ * Returns a [GdxMap] containing only entries matching the given [predicate].
+ */
+inline fun <Key, Value> GdxMap<Key, Value>.filter(predicate: (Entry<Key, Value>) -> Boolean): GdxMap<Key, Value> {
+  val destination = GdxMap<Key, Value>()
+  for(item in this) {
+    if(predicate(item)) {
+      destination[item.key] = item.value
+    }
+  }
+  return destination
+}
+
+
+/**
+ * Returns a single [GdxArray] of all elements from all collections in the given [GdxMap].
+ */
+inline fun <Key, Type, Value: Iterable<Type>> GdxMap<Key, out Value>.flatten(): GdxArray<Type> {
+  val destination = GdxArray<Type>()
+  for(item in this) {
+    destination.addAll(item.value)
+  }
+  return destination
+}
+
+
+/**
+ * Returns a single [GdxArray] of all elements yielded from results of transform function being invoked
+ * on each entry of original [GdxArray].
+ */
+inline fun <Key, Value, R> GdxMap<Key, Value>.flatMap(transform: (Entry<Key, Value>) -> Iterable<R>): GdxArray<R> {
+  return this.map(transform).flatten()
+}

--- a/collections/src/main/kotlin/ktx/collections/sets.kt
+++ b/collections/src/main/kotlin/ktx/collections/sets.kt
@@ -151,7 +151,7 @@ inline fun <Type> GdxSet<Type>.iterate(action: (Type, MutableIterator<Type>) -> 
  */
 inline fun <Type, R> GdxSet<Type>.map(transform: (Type) -> R): GdxSet<R> {
   val destination = GdxSet<R>(this.size)
-  for(item in this) {
+  for (item in this) {
     destination.add(transform(item))
   }
   return destination
@@ -162,8 +162,8 @@ inline fun <Type, R> GdxSet<Type>.map(transform: (Type) -> R): GdxSet<R> {
  */
 inline fun <Type> GdxSet<Type>.filter(predicate: (Type) -> Boolean): GdxSet<Type> {
   val destination = GdxSet<Type>()
-  for(item in this) {
-    if(predicate(item)) {
+  for (item in this) {
+    if (predicate(item)) {
       destination.add(item)
     }
   }
@@ -173,9 +173,9 @@ inline fun <Type> GdxSet<Type>.filter(predicate: (Type) -> Boolean): GdxSet<Type
 /**
  * Returns a single [GdxSet] of all elements from all collections in the given [GdxSet].
  */
-inline fun <Type, C: Iterable<Type>> GdxSet<out C>.flatten(): GdxSet<Type> {
+inline fun <Type, C : Iterable<Type>> GdxSet<out C>.flatten(): GdxSet<Type> {
   val destination = GdxSet<Type>()
-  for(item in this) {
+  for (item in this) {
     destination.addAll(item)
   }
   return destination

--- a/collections/src/main/kotlin/ktx/collections/sets.kt
+++ b/collections/src/main/kotlin/ktx/collections/sets.kt
@@ -3,6 +3,7 @@
 package ktx.collections
 
 import com.badlogic.gdx.utils.IntSet
+import com.badlogic.gdx.utils.ObjectMap
 import com.badlogic.gdx.utils.ObjectSet
 
 /** Alias for [com.badlogic.gdx.utils.ObjectSet]. Added for consistency with other collections and factory methods. */
@@ -142,6 +143,50 @@ operator fun <Type> GdxSet<Type>.minus(elements: Array<out Type>): GdxSet<Type> 
 inline fun <Type> GdxSet<Type>.iterate(action: (Type, MutableIterator<Type>) -> Unit) {
   val iterator = iterator()
   while (iterator.hasNext) action(iterator.next(), iterator)
+}
+
+/**
+ * Returns a [GdxSet] containing the results of applying the given [transform] function
+ * to each entry in the original [GdxSet].
+ */
+inline fun <Type, R> GdxSet<Type>.map(transform: (Type) -> R): GdxSet<R> {
+  val destination = GdxSet<R>(this.size)
+  for(item in this) {
+    destination.add(transform(item))
+  }
+  return destination
+}
+
+/**
+ * Returns a [GdxSet] containing only elements matching the given [predicate].
+ */
+inline fun <Type> GdxSet<Type>.filter(predicate: (Type) -> Boolean): GdxSet<Type> {
+  val destination = GdxSet<Type>()
+  for(item in this) {
+    if(predicate(item)) {
+      destination.add(item)
+    }
+  }
+  return destination
+}
+
+/**
+ * Returns a single [GdxSet] of all elements from all collections in the given [GdxSet].
+ */
+inline fun <Type, C: Iterable<Type>> GdxSet<out C>.flatten(): GdxSet<Type> {
+  val destination = GdxSet<Type>()
+  for(item in this) {
+    destination.addAll(item)
+  }
+  return destination
+}
+
+/**
+ * Returns a single [GdxSet] of all elements yielded from results of transform function being invoked
+ * on each element of original [GdxSet].
+ */
+inline fun <Type, R> GdxSet<Type>.flatMap(transform: (Type) -> Iterable<R>): GdxSet<R> {
+  return this.map(transform).flatten()
 }
 
 /**

--- a/collections/src/main/kotlin/ktx/collections/sets.kt
+++ b/collections/src/main/kotlin/ktx/collections/sets.kt
@@ -1,4 +1,4 @@
-@file:Suppress("NOTHING_TO_INLINE")
+@file:Suppress("NOTHING_TO_INLINE", "LoopToCallChain")
 
 package ktx.collections
 

--- a/collections/src/test/kotlin/ktx/collections/arraysTest.kt
+++ b/collections/src/test/kotlin/ktx/collections/arraysTest.kt
@@ -359,9 +359,7 @@ class ArraysTest {
     val result = array.map { it * 2 }
 
     assertTrue(result is GdxArray)
-    assertEquals(2, result[0])
-    assertEquals(4, result[1])
-    assertEquals(6, result[2])
+    assertEquals(GdxArray.with(2, 4, 6), result)
   }
 
   @Test
@@ -370,10 +368,7 @@ class ArraysTest {
     val result = array.filter { it % 2 == 1 }
 
     assertTrue(result is GdxArray)
-    assertEquals(3, result.size)
-    assertEquals(1, result[0])
-    assertEquals(3, result[1])
-    assertEquals(5, result[2])
+    assertEquals(GdxArray.with(1, 3, 5), result)
   }
 
   @Test
@@ -382,19 +377,16 @@ class ArraysTest {
     val result = array.flatten()
 
     assertTrue(result is GdxArray)
-    assertEquals(3, result.size)
-    assertEquals(1, result[0])
-    assertEquals(2, result[1])
-    assertEquals(3, result[2])
+    assertEquals(GdxArray.with(1, 2, 3), result)
   }
 
   @Test
   fun `should map elements to lists and flatten them into a new GdxArray`() {
     val array = GdxArray.with(1, 2, 3)
-    val result = array.flatMap { List(it) { "" }  }
+    val result = array.flatMap { counter -> List(counter) { counter }  }
 
     assertTrue(result is GdxArray)
-    assertEquals(6, result.size)
+    assertEquals(GdxArray.with(1, 2, 2, 3, 3, 3), result)
   }
 
   @Test

--- a/collections/src/test/kotlin/ktx/collections/arraysTest.kt
+++ b/collections/src/test/kotlin/ktx/collections/arraysTest.kt
@@ -383,7 +383,7 @@ class ArraysTest {
   @Test
   fun `should map elements to lists and flatten them into a new GdxArray`() {
     val array = GdxArray.with(1, 2, 3)
-    val result = array.flatMap { counter -> List(counter) { counter }  }
+    val result = array.flatMap { counter -> List(counter) { counter } }
 
     assertTrue(result is GdxArray)
     assertEquals(GdxArray.with(1, 2, 2, 3, 3, 3), result)

--- a/collections/src/test/kotlin/ktx/collections/arraysTest.kt
+++ b/collections/src/test/kotlin/ktx/collections/arraysTest.kt
@@ -391,7 +391,7 @@ class ArraysTest {
   @Test
   fun `should map elements to lists and flatten them into a new GdxArray`() {
     val array = GdxArray.with(1, 2, 3)
-    val result = array.flatMap { MutableList(it) { "" }  }
+    val result = array.flatMap { List(it) { "" }  }
 
     assertTrue(result is GdxArray)
     assertEquals(6, result.size)

--- a/collections/src/test/kotlin/ktx/collections/arraysTest.kt
+++ b/collections/src/test/kotlin/ktx/collections/arraysTest.kt
@@ -1,7 +1,9 @@
 package ktx.collections
 
+import com.badlogic.gdx.Gdx
 import org.junit.Assert.*
 import org.junit.Test
+import java.util.*
 
 /**
  * Tests utilities for LibGDX custom ArrayList equivalent - Array.
@@ -349,6 +351,50 @@ class ArraysTest {
     assertEquals("Twenty-one", array[0])
     assertEquals("Eleven", array[1])
     assertEquals("One", array[2])
+  }
+
+  @Test
+  fun `should map elements into a new GdxArray`() {
+    val array = GdxArray.with(1, 2, 3)
+    val result = array.map { it * 2 }
+
+    assertTrue(result is GdxArray)
+    assertEquals(2, result[0])
+    assertEquals(4, result[1])
+    assertEquals(6, result[2])
+  }
+
+  @Test
+  fun `should filter elements into a new GdxArray`() {
+    val array = GdxArray.with(1, 2, 3, 4, 5)
+    val result = array.filter { it % 2 == 1 }
+
+    assertTrue(result is GdxArray)
+    assertEquals(3, result.size)
+    assertEquals(1, result[0])
+    assertEquals(3, result[1])
+    assertEquals(5, result[2])
+  }
+
+  @Test
+  fun `should flatten elements into a new GdxArray`() {
+    val array = GdxArray.with(GdxArray.with(1), listOf<Int>(), LinkedList(arrayListOf(2, 3)))
+    val result = array.flatten()
+
+    assertTrue(result is GdxArray)
+    assertEquals(3, result.size)
+    assertEquals(1, result[0])
+    assertEquals(2, result[1])
+    assertEquals(3, result[2])
+  }
+
+  @Test
+  fun `should map elements to lists and flatten them into a new GdxArray`() {
+    val array = GdxArray.with(1, 2, 3)
+    val result = array.flatMap { MutableList(it) { "" }  }
+
+    assertTrue(result is GdxArray)
+    assertEquals(6, result.size)
   }
 
   @Test

--- a/collections/src/test/kotlin/ktx/collections/listsTest.kt
+++ b/collections/src/test/kotlin/ktx/collections/listsTest.kt
@@ -261,7 +261,7 @@ class PooledListTest {
   @Test
   fun `should map elements to lists and flatten them into a new GdxList`() {
     val list = gdxListOf(1, 2, 3)
-    val result = list.flatMap { List(it) { "" }  }
+    val result = list.flatMap { List(it) { "" } }
 
     assertTrue(result is GdxList)
     assertEquals(6, result.size)

--- a/collections/src/test/kotlin/ktx/collections/listsTest.kt
+++ b/collections/src/test/kotlin/ktx/collections/listsTest.kt
@@ -2,7 +2,7 @@ package ktx.collections
 
 import org.junit.Assert.*
 import org.junit.Test
-import java.util.NoSuchElementException
+import java.util.*
 
 /**
  * Tests general [PooledList] utilities.
@@ -222,6 +222,49 @@ class PooledListTest {
     assertEquals(0, list.size)
     assertTrue(list.isEmpty)
     assertEquals(0, NodePool.free) // Nodes should not be returned to the pool.
+  }
+
+  @Test
+  fun `should map elements into a new GdxList`() {
+    val list = gdxListOf(1, 2, 3)
+    val result = list.map { it * 2 }
+
+    assertTrue(result is GdxList)
+    assertEquals(3, result.size)
+    assertEquals(2, result.first)
+    assertEquals(6, result.last)
+  }
+
+  @Test
+  fun `should filter elements into a new GdxList`() {
+    val list = gdxListOf(1, 2, 3, 4, 5)
+    val result = list.filter { it % 2 == 1 }
+
+    assertTrue(result is GdxList)
+    assertEquals(3, result.size)
+    assertEquals(1, result.first)
+    assertEquals(5, result.last)
+  }
+
+  @Test
+  fun `should flatten elements into a new GdxList`() {
+    val list = gdxListOf(GdxArray.with(1), listOf<Int>(), LinkedList(arrayListOf(2, 3)))
+    val result = list.flatten()
+
+    assertTrue(result is GdxList)
+    assertEquals(3, result.size)
+    assertEquals(3, result.size)
+    assertEquals(1, result.first)
+    assertEquals(3, result.last)
+  }
+
+  @Test
+  fun `should map elements to lists and flatten them into a new GdxList`() {
+    val list = gdxListOf(1, 2, 3)
+    val result = list.flatMap { List(it) { "" }  }
+
+    assertTrue(result is GdxList)
+    assertEquals(6, result.size)
   }
 
   @Test(expected = NoSuchElementException::class)

--- a/collections/src/test/kotlin/ktx/collections/mapsTest.kt
+++ b/collections/src/test/kotlin/ktx/collections/mapsTest.kt
@@ -411,7 +411,7 @@ class MapsTest {
   @Test
   fun `should map elements to lists and flatten them into a new GdxArray`() {
     val map = gdxMapOf("One" to 1, "Two" to 2, "Three" to 3)
-    val result = map.flatMap { e -> List(e.value) { e.value }  }
+    val result = map.flatMap { e -> List(e.value) { e.value } }
     result.sort()
 
     assertTrue(result is GdxArray)

--- a/collections/src/test/kotlin/ktx/collections/mapsTest.kt
+++ b/collections/src/test/kotlin/ktx/collections/mapsTest.kt
@@ -386,9 +386,7 @@ class MapsTest {
     val result = map.map { it.value * 2 }
 
     assertTrue(result is GdxMap)
-    assertEquals(2, result["One"])
-    assertEquals(4, result["Two"])
-    assertEquals(6, result["Three"])
+    assertEquals(gdxMapOf("One" to 2, "Two" to 4, "Three" to 6), result)
   }
 
   @Test
@@ -397,10 +395,7 @@ class MapsTest {
     val result = map.filter { it.value % 2 == 1 }
 
     assertTrue(result is GdxMap)
-    assertEquals(3, result.size)
-    assertEquals(1, result["One"])
-    assertEquals(3, result["Three"])
-    assertEquals(5, result["Five"])
+    assertEquals(gdxMapOf("One" to 1, "Three" to 3, "Five" to 5), result)
   }
 
   @Test
@@ -410,18 +405,17 @@ class MapsTest {
 
     assertTrue(result is GdxArray)
     assertEquals(3, result.size)
-    assertTrue(1 in result)
-    assertTrue(2 in result)
-    assertTrue(3 in result)
+    assertEquals(GdxArray.with(1, 2, 3), result)
   }
 
   @Test
   fun `should map elements to lists and flatten them into a new GdxArray`() {
     val map = gdxMapOf("One" to 1, "Two" to 2, "Three" to 3)
-    val result = map.flatMap { List(it.value) { "" }  }
+    val result = map.flatMap { e -> List(e.value) { e.value }  }
+    result.sort()
 
     assertTrue(result is GdxArray)
-    assertEquals(6, result.size)
+    assertEquals(GdxArray.with(1, 2, 2, 3, 3, 3), result)
   }
 
 }

--- a/collections/src/test/kotlin/ktx/collections/mapsTest.kt
+++ b/collections/src/test/kotlin/ktx/collections/mapsTest.kt
@@ -4,6 +4,7 @@ import com.badlogic.gdx.utils.*
 import com.badlogic.gdx.utils.Array
 import org.junit.Assert.*
 import org.junit.Test
+import java.util.*
 
 /**
  * Tests utilities for LibGDX custom HashMap equivalent - [ObjectMap].
@@ -378,4 +379,49 @@ class MapsTest {
     assertEquals("Key", key)
     assertEquals(10, value)
   }
+
+  @Test
+  fun `should map elements into a new GdxMap`() {
+    val map = gdxMapOf("One" to 1, "Two" to 2, "Three" to 3)
+    val result = map.map { it.value * 2 }
+
+    assertTrue(result is GdxMap)
+    assertEquals(2, result["One"])
+    assertEquals(4, result["Two"])
+    assertEquals(6, result["Three"])
+  }
+
+  @Test
+  fun `should filter elements into a new GdxMap`() {
+    val map = gdxMapOf("One" to 1, "Two" to 2, "Three" to 3, "Four" to 4, "Five" to 5)
+    val result = map.filter { it.value % 2 == 1 }
+
+    assertTrue(result is GdxMap)
+    assertEquals(3, result.size)
+    assertEquals(1, result["One"])
+    assertEquals(3, result["Three"])
+    assertEquals(5, result["Five"])
+  }
+
+  @Test
+  fun `should flatten elements into a new GdxArray`() {
+    val map = gdxMapOf(1 to GdxArray.with(1), 2 to listOf<Int>(), 3 to LinkedList(arrayListOf(2, 3)))
+    val result = map.flatten()
+
+    assertTrue(result is GdxArray)
+    assertEquals(3, result.size)
+    assertTrue(result.contains(1))
+    assertTrue(result.contains(2))
+    assertTrue(result.contains(3))
+  }
+
+  @Test
+  fun `should map elements to lists and flatten them into a new GdxArray`() {
+    val map = gdxMapOf("One" to 1, "Two" to 2, "Three" to 3)
+    val result = map.flatMap { MutableList(it.value) { "" }  }
+
+    assertTrue(result is GdxArray)
+    assertEquals(6, result.size)
+  }
+
 }

--- a/collections/src/test/kotlin/ktx/collections/mapsTest.kt
+++ b/collections/src/test/kotlin/ktx/collections/mapsTest.kt
@@ -410,15 +410,15 @@ class MapsTest {
 
     assertTrue(result is GdxArray)
     assertEquals(3, result.size)
-    assertTrue(result.contains(1))
-    assertTrue(result.contains(2))
-    assertTrue(result.contains(3))
+    assertTrue(1 in result)
+    assertTrue(2 in result)
+    assertTrue(3 in result)
   }
 
   @Test
   fun `should map elements to lists and flatten them into a new GdxArray`() {
     val map = gdxMapOf("One" to 1, "Two" to 2, "Three" to 3)
-    val result = map.flatMap { MutableList(it.value) { "" }  }
+    val result = map.flatMap { List(it.value) { "" }  }
 
     assertTrue(result is GdxArray)
     assertEquals(6, result.size)

--- a/collections/src/test/kotlin/ktx/collections/setsTest.kt
+++ b/collections/src/test/kotlin/ktx/collections/setsTest.kt
@@ -3,6 +3,7 @@ package ktx.collections
 import com.badlogic.gdx.utils.ObjectSet
 import org.junit.Assert.*
 import org.junit.Test
+import java.util.*
 
 /**
  * Tests utilities for LibGDX custom HashSet equivalent - [ObjectSet].
@@ -219,6 +220,53 @@ class SetsTest {
     set.iterate { value, iterator -> if (value == "2") iterator.remove() }
     assertEquals(2, set.size)
     assertFalse("2" in set)
+  }
+
+  @Test
+  fun `should map elements into a new GdxSet`() {
+    val set = GdxSet.with(1, 2, 3)
+    val result = set.map { it * 2 }
+
+    assertTrue(result is GdxSet)
+    assertTrue(2 in result)
+    assertTrue(4 in result)
+    assertTrue(6 in result)
+  }
+
+  @Test
+  fun `should filter elements into a new GdxSet`() {
+    val set = GdxSet.with(1, 2, 3, 4, 5)
+    val result = set.filter { it % 2 == 1 }
+
+    assertTrue(result is GdxSet)
+    assertEquals(3, result.size)
+    assertTrue(1 in result)
+    assertTrue(3 in result)
+    assertTrue(5 in result)
+  }
+
+  @Test
+  fun `should flatten elements into a new GdxSet`() {
+    val set = GdxSet.with(GdxArray.with(1, 2), listOf<Int>(), LinkedList(arrayListOf(2, 3)))
+    val result = set.flatten()
+
+    assertTrue(result is GdxSet)
+    assertEquals(3, result.size)
+    assertTrue(1 in result)
+    assertTrue(2 in result)
+    assertTrue(3 in result)
+  }
+
+  @Test
+  fun `should map elements to lists and flatten them into a new GdxSet`() {
+    val set = GdxSet.with(1, 2, 3)
+    val result = set.flatMap { count -> List(count) { it }  }
+
+    assertTrue(result is GdxSet)
+    assertEquals(3, result.size)
+    assertTrue(0 in result)
+    assertTrue(1 in result)
+    assertTrue(2 in result)
   }
 
   @Test

--- a/collections/src/test/kotlin/ktx/collections/setsTest.kt
+++ b/collections/src/test/kotlin/ktx/collections/setsTest.kt
@@ -260,7 +260,7 @@ class SetsTest {
   @Test
   fun `should map elements to lists and flatten them into a new GdxSet`() {
     val set = GdxSet.with(1, 2, 3)
-    val result = set.flatMap { count -> List(count) { it }  }
+    val result = set.flatMap { count -> List(count) { it } }
 
     assertTrue(result is GdxSet)
     assertEquals(3, result.size)


### PR DESCRIPTION
#58 

Add

* `map`
* `filter`
* `flatten`
* `flatMap`

methods to 

* `GdxArray`
* `GdxList`
* `GdxMap`
* `GdxSet`


By the way I feel using `assertEqual` to check elements in a collection is pretty tedious and there must be a way to wrap it as an one-liner like `assertThat(result, SomeMagicalMatcher(listOf(1,2,3)))` or something. But I don't want to do refactor here.