### PR TITLE
Add higher-order function parameters to bindSingleton() functions.

### DIFF
--- a/inject/src/main/kotlin/ktx/inject/inject.kt
+++ b/inject/src/main/kotlin/ktx/inject/inject.kt
@@ -141,6 +141,13 @@ open class Context : Disposable {
   inline fun <reified Type : Any> bindSingleton(singleton: Type) = bind(SingletonProvider(singleton))
 
   /**
+   * Allows to bind a singleton to the chosen class.
+   * @param provider will be invoked and the return value converted to a provider that always returns the same instance.
+   * @throws InjectionException if provider for the selected type is already defined.
+   */
+  inline fun <reified Type : Any> bindSingleton(provider: () -> Type) = bind(SingletonProvider(provider()))
+
+  /**
    * Allows to bind a provider to multiple classes in hierarchy of the provided instances class.
    * @param to list of interfaces and classes in the class hierarchy of the objects provided by the provider. Any time
    *    any of the passed classes will be requested for injection, the selected provider will be invoked.
@@ -151,13 +158,23 @@ open class Context : Disposable {
 
   /**
    * Allows to bind a singleton instance to multiple classes in its hierarchy.
-   * @param singleton instance of class compatible with the passed types.
    * @param to list of interfaces and classes in the class hierarchy of the singleton. Any time any of the passed classes
    *    will be requested for injection, the selected singleton will be returned.
+   * @param singleton instance of class compatible with the passed types.
    * @throws InjectionException if provider for any of the selected types is already defined.
    */
-  fun <Type : Any> bindSingleton(singleton: Type, vararg to: Class<out Type>)
-      = bind(*to, provider = SingletonProvider(singleton))
+  fun <Type : Any> bindSingleton(vararg to: Class<out Type>, singleton: Type)
+          = bind(*to, provider = SingletonProvider(singleton))
+
+  /**
+   * Allows to bind a provider instance to multiple classes in its hierarchy.
+   * @param to list of interfaces and classes in the class hierarchy of the provider. Any time any of the passed classes
+   *    will be requested for injection, the selected provider will be returned.
+   * @param provider provides instances of classes compatible with the passed types.
+   * @throws InjectionException if provider for any of the selected types is already defined.
+   */
+  fun <Type : Any> bindSingleton(vararg to: Class<out Type>, provider: () -> Type)
+          = bind(*to, provider = SingletonProvider(provider()))
 
   /**
    * Removes all user-defined providers and singletons from the context. [Context] itselfs will still be present and


### PR DESCRIPTION
I recommend to swap the bindSingleton parameters and put the "vararg to: Class<out Type>" as first paramter, like it is already done for the bind() functions.

Also added higher-order function parameters which allow now to use lambda expression for bindSingleton() as well.

F.e.

```
bindSingleton {
     if (something) AndroidImplementation() else DesktopImplementation()
}

bindSingleton (Implementation::class.java) {
     if (something) AndroidImplementation() else DesktopImplementation()
}
```