### PR TITLE
Add higher-order function parameters to bindSingleton() functions.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,8 @@ the implementation and making configuration blocks optional.
 - **[FEATURE]** (`ktx-vis-style`) Initiation blocks of VisUI actor styles are now optional.
 - **[FEATURE]** (`ktx-box2d`) Initiation blocks of fixtures and joints are now optional thanks to default lambda
 parameters in inlined functions.
+- **[FEATURE]** (`ktx-inject`) Add higher-order function parameters for `bindSingleton` to allow the use of lambda
+expressions.
 
 ```kotlin
 fun createCircle(body: Body) {

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ factory method supporting both syntax variants per widget. This should not affec
 Kotlin 1.2 usage.
 - **[CHANGE]** (`ktx-ashley`) Default functional parameters were added to `create`, `entity` and `with`, simplifying
 the implementation and making configuration blocks optional.
+- **[CHANGE]** (`ktx-inject`) Parameters of `bindSingleton` have been swapped to be more congruent with `bind` functions.
 - **[FEATURE]** (`ktx-style`) Initiation blocks of `Skin` and Scene2D actor styles are now optional.
 - **[FEATURE]** (`ktx-vis-style`) Initiation blocks of VisUI actor styles are now optional.
 - **[FEATURE]** (`ktx-box2d`) Initiation blocks of fixtures and joints are now optional thanks to default lambda

--- a/inject/src/main/kotlin/ktx/inject/inject.kt
+++ b/inject/src/main/kotlin/ktx/inject/inject.kt
@@ -141,6 +141,13 @@ open class Context : Disposable {
   inline fun <reified Type : Any> bindSingleton(singleton: Type) = bind(SingletonProvider(singleton))
 
   /**
+   * Allows to bind a singleton to the chosen class.
+   * @param provider will be invoked and the return value converted to a provider that always returns the same instance.
+   * @throws InjectionException if provider for the selected type is already defined.
+   */
+  inline fun <reified Type : Any> bindSingleton(provider: () -> Type) = bind(SingletonProvider(provider()))
+
+  /**
    * Allows to bind a provider to multiple classes in hierarchy of the provided instances class.
    * @param to list of interfaces and classes in the class hierarchy of the objects provided by the provider. Any time
    *    any of the passed classes will be requested for injection, the selected provider will be invoked.
@@ -158,6 +165,16 @@ open class Context : Disposable {
    */
   fun <Type : Any> bindSingleton(vararg to: Class<out Type>, singleton: Type)
       = bind(*to, provider = SingletonProvider(singleton))
+
+  /**
+   * Allows to bind the result of the provider to multiple classes in its hierarchy.
+   * @param to list of interfaces and classes in the class hierarchy of the provider. Any time any of the passed classes
+   *    will be requested for injection, the selected provider will be returned.
+   * @param provider provides instances of classes compatible with the passed types.
+   * @throws InjectionException if provider for any of the selected types is already defined.
+   */
+  inline fun <Type : Any> bindSingleton(vararg to: Class<out Type>, provider: () -> Type)
+      = bind(*to, provider = SingletonProvider(provider()))
 
   /**
    * Removes all user-defined providers and singletons from the context. [Context] itselfs will still be present and

--- a/inject/src/main/kotlin/ktx/inject/inject.kt
+++ b/inject/src/main/kotlin/ktx/inject/inject.kt
@@ -151,12 +151,12 @@ open class Context : Disposable {
 
   /**
    * Allows to bind a singleton instance to multiple classes in its hierarchy.
-   * @param singleton instance of class compatible with the passed types.
    * @param to list of interfaces and classes in the class hierarchy of the singleton. Any time any of the passed classes
    *    will be requested for injection, the selected singleton will be returned.
+   * @param singleton instance of class compatible with the passed types.
    * @throws InjectionException if provider for any of the selected types is already defined.
    */
-  fun <Type : Any> bindSingleton(singleton: Type, vararg to: Class<out Type>)
+  fun <Type : Any> bindSingleton(vararg to: Class<out Type>, singleton: Type)
       = bind(*to, provider = SingletonProvider(singleton))
 
   /**

--- a/inject/src/test/kotlin/ktx/inject/injectTest.kt
+++ b/inject/src/test/kotlin/ktx/inject/injectTest.kt
@@ -56,7 +56,7 @@ class DependencyInjectionTest {
   fun `should bind singletons to multiple types`() {
     val singleton = java.lang.String("Singleton")
 
-    context.bindSingleton(singleton, String::class.java, CharSequence::class.java)
+    context.bindSingleton(String::class.java, CharSequence::class.java) { singleton }
 
     assertTrue(context.contains<String>())
     assertTrue(context.contains<CharSequence>())
@@ -145,7 +145,7 @@ class DependencyInjectionTest {
 
   @Test(expected = InjectionException::class)
   fun `should throw exception when trying to register singleton for same types`() {
-    context.bindSingleton("Should throw.", String::class.java, String::class.java)
+    context.bindSingleton(String::class.java, String::class.java) { "Should throw." }
   }
 
   @Test

--- a/inject/src/test/kotlin/ktx/inject/injectTest.kt
+++ b/inject/src/test/kotlin/ktx/inject/injectTest.kt
@@ -66,6 +66,38 @@ class DependencyInjectionTest {
   }
 
   @Test
+  fun `should bind singletons using provider's result`() {
+    val singleton = java.lang.String("Singleton")
+
+    context.bindSingleton { singleton }
+
+    assertTrue(context.contains<String>())
+    val provided = context.inject<String>()
+    assertSame(singleton, provided)
+    assertSame(context.inject<String>(), context.inject<String>())
+
+    val provider = context.provider<String>()
+    assertSame(singleton, provider())
+    assertSame(provider(), provider())
+  }
+
+  @Test
+  fun `should bind singleton using provider's result with given type parameter`() {
+    val singleton = java.lang.String("Singleton")
+
+    context.bindSingleton(CharSequence::class.java) { singleton }
+
+    assertTrue(context.contains<CharSequence>())
+    val provided = context.inject<CharSequence>()
+    assertSame(singleton, provided)
+    assertSame(context.inject<CharSequence>(), context.inject<CharSequence>())
+
+    val provider = context.provider<CharSequence>()
+    assertSame(singleton, provider())
+    assertSame(provider(), provider())
+  }
+
+  @Test
   fun `should remove singletons`() {
     val singleton = Random()
     context.bindSingleton(singleton)


### PR DESCRIPTION
I recommend to swap the bindSingleton parameters and put the "vararg to: Class<out Type>" as first paramter, like it is already done for the bind() functions.

Also added higher-order function parameters which allow now to use lambda expression for bindSingleton() as well.

F.e.

```
bindSingleton {
     if (something) AndroidImplementation() else DesktopImplementation()
}

bindSingleton (Implementation::class.java) {
     if (something) AndroidImplementation() else DesktopImplementation()
}
```

Hope I did everything right this time :)