### PR TITLE
Throw an appropriate exception if createComponent fails

### DIFF
--- a/ashley/src/main/kotlin/ktx/ashley/engines.kt
+++ b/ashley/src/main/kotlin/ktx/ashley/engines.kt
@@ -3,6 +3,7 @@ package ktx.ashley
 import com.badlogic.ashley.core.Component
 import com.badlogic.ashley.core.Engine
 import com.badlogic.ashley.core.Entity
+import kotlin.reflect.KClass
 
 /**
  * An [Entity] created by the provided [Engine].
@@ -48,8 +49,8 @@ inline fun <reified T : Component> Engine.create(configure: T.() -> Unit = {}): 
   return try {
     createComponent(T::class.java)
   } catch (e: Exception) {
-    throw CreateComponentException(T::class.java, e)
-  }?.apply(configure)?:throw CreateComponentException(T::class.java)
+    throw CreateComponentException(T::class, e)
+  }?.apply(configure)?:throw CreateComponentException(T::class)
 }
 
 /**
@@ -73,4 +74,4 @@ inline fun Engine.entity(configure: EngineEntity.() -> Unit = {}): Entity {
   return entity
 }
 
-class CreateComponentException(type: Class<*>, cause: Throwable? = null): RuntimeException("Could not instantiate component ${type.name} - the component must have a visible no-arg constructor", cause)
+class CreateComponentException(type: KClass<*>, cause: Throwable? = null): RuntimeException("Could not instantiate component ${type::java.name} - the component must have a visible no-arg constructor", cause)

--- a/ashley/src/test/kotlin/ktx/ashley/EnginesSpec.kt
+++ b/ashley/src/test/kotlin/ktx/ashley/EnginesSpec.kt
@@ -1,7 +1,10 @@
 package ktx.ashley
 
+import com.badlogic.ashley.core.Component
+import com.badlogic.ashley.core.Engine
 import com.badlogic.ashley.core.PooledEngine
 import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.assertThatExceptionOfType
 import org.jetbrains.spek.api.Spek
 import org.jetbrains.spek.api.dsl.describe
 import org.jetbrains.spek.api.dsl.it
@@ -16,6 +19,23 @@ object EnginesSpec : Spek({
       it("should create a pooled component with reified type") {
         assertThat(component.x).isEqualTo(0f)
         assertThat(component.y).isEqualTo(0f)
+      }
+    }
+    describe("creating a component that has no no-arg constructor") {
+      @Suppress("UNUSED_PARAMETER")
+      class NoNoArgConstructorComponent(body: String): Component
+
+      it("should throw an exception if the non-pooled engine was unable to create the component") {
+        val nonPooledEngine = Engine()
+        assertThatExceptionOfType(CreateComponentException::class.java).isThrownBy {
+          nonPooledEngine.create<NoNoArgConstructorComponent>()
+        }
+      }
+
+      it("should throw an exception if the pooled engine was unable to create the component") {
+        assertThatExceptionOfType(CreateComponentException::class.java).isThrownBy {
+          engine.create<NoNoArgConstructorComponent>()
+        }
       }
     }
     describe("creating a component with configuration") {


### PR DESCRIPTION
Note that PooledEngine already throws a RuntimeException with an appropriate message "Class cannot be created (missing no-arg constructor)", instead of returning null.

`Engine.create` still catches the Exception and throws a`CreateComponentException` for consistency between the two Engine types.