### PR TITLE
Update style.kt

### DIFF
--- a/style/src/main/kotlin/ktx/style/style.kt
+++ b/style/src/main/kotlin/ktx/style/style.kt
@@ -62,6 +62,16 @@ inline fun skin(atlas: TextureAtlas, init: (@SkinDsl Skin).(Skin) -> Unit = {}):
  */
 inline infix operator fun <reified Resource : Any> Skin.get(name: String): Resource = this[name, Resource::class.java]
 
+
+/**
+ * Utility function that makes it easier to access [Skin] assets.
+ * @param name name of the requested resource.
+ * @return resource of the specified type with the selected name.
+ * @throws GdxRuntimeException if unable to find the resource.
+ */
+inline infix operator fun <reified Resource : Any, E : Enum<E>>  Skin.get(name: E): Resource = this[name.toString(), Resource::class.java]
+
+
 /**
  * Utility function that makes it easier to add [Skin] assets.
  * @param name name of the passed resource.
@@ -69,6 +79,14 @@ inline infix operator fun <reified Resource : Any> Skin.get(name: String): Resou
  */
 inline operator fun <reified Resource : Any> Skin.set(name: String, resource: Resource) =
     this.add(name, resource, Resource::class.java)
+
+/**
+ * Utility function that makes it easier to add [Skin] assets.
+ * @param name name of the passed resource.
+ * @param resource will be added to the skin and mapped to the selected name.
+ */
+inline operator fun <reified Resource : Any , E : Enum<E>> Skin.set(name: E, resource: Resource) =
+        this.add(name.toString(), resource, Resource::class.java)
 
 /**
  * Utility function for adding existing styles to the skin. Mostly for internal use.


### PR DESCRIPTION
Type-safe enum names without invoke() method and brackets:

enum class Drawables {
  buttonUp,
  buttonDown,
  buttonChecked; 
}

skin(myAtlas) {
  button {
    up = it[buttonUp]
    down = it[buttonDown]
  }
}
