### PR TITLE
Type-safe enum names without invoke() method and brackets

### DIFF
--- a/style/src/main/kotlin/ktx/style/style.kt
+++ b/style/src/main/kotlin/ktx/style/style.kt
@@ -63,12 +63,28 @@ inline fun skin(atlas: TextureAtlas, init: (@SkinDsl Skin).(Skin) -> Unit = {}):
 inline infix operator fun <reified Resource : Any> Skin.get(name: String): Resource = this[name, Resource::class.java]
 
 /**
+ * Utility function that makes it easier to access [Skin] assets.
+ * @param name name of the requested resource.
+ * @return resource of the specified type with the selected name.
+ * @throws GdxRuntimeException if unable to find the resource.
+ */
+inline infix operator fun <reified Resource : Any, E : Enum<E>>  Skin.get(name: E): Resource = this[name.toString()]
+
+/**
  * Utility function that makes it easier to add [Skin] assets.
  * @param name name of the passed resource.
  * @param resource will be added to the skin and mapped to the selected name.
  */
 inline operator fun <reified Resource : Any> Skin.set(name: String, resource: Resource) =
     this.add(name, resource, Resource::class.java)
+
+/**
+ * Utility function that makes it easier to add [Skin] assets.
+ * @param name name of the passed resource.
+ * @param resource will be added to the skin and mapped to the selected name.
+ */
+inline operator fun <reified Resource : Any , E : Enum<E>> Skin.set(name: E, resource: Resource) =
+        this.set(name.toString(), resource)
 
 /**
  * Utility function for adding existing styles to the skin. Mostly for internal use.

--- a/style/src/test/kotlin/ktx/style/styleTest.kt
+++ b/style/src/test/kotlin/ktx/style/styleTest.kt
@@ -24,6 +24,7 @@ import com.badlogic.gdx.scenes.scene2d.utils.Drawable
 import io.kotlintest.matchers.shouldBe
 import io.kotlintest.matchers.shouldNotBe
 import io.kotlintest.mock.mock
+import ktx.style.StyleTest.MockEnum.mock
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertSame
 import org.junit.Test
@@ -116,6 +117,16 @@ class StyleTest {
     skin["name"] = "Asset."
 
     skin.get<String>("name") shouldBe "Asset."
+  }
+
+  @Test
+  fun `should add and extract resource with brace operator with enum name`() {
+    val skin = Skin()
+    skin[mock] = "Test."
+
+    val resource: String = skin[mock]
+
+    resource shouldBe "Test."
   }
 
   @Test
@@ -641,5 +652,10 @@ class StyleTest {
     val style = skin.get<WindowStyle>("new")
     assertEquals(drawable, style.background)
     assertEquals(drawable, style.stageBackground)
+  }
+
+  /** For [StyleTest] tests. */
+  internal enum class MockEnum {
+    mock
   }
 }


### PR DESCRIPTION
Example:

enum class Drawables {
buttonUp,
buttonDown,
buttonChecked;
}

skin(myAtlas) {
button {
up = it[buttonUp]
down = it[buttonDown]
}
}