### PR TITLE
Added default parameter value for Skin.get

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 #### 1.9.9-SNAPSHOT
 
 - **[UPDATE]** Updated to Kotlin 1.3.21.
+- **[CHANGE]** (`ktx-style`) `Skin.get` is no longer infix to allow a default parameter.
 - **[FEATURE]** (`ktx-assets`) Added `TextAssetLoader` that can be registered in an `AssetManager` to load text files asynchronously.
 
 #### 1.9.9-b1

--- a/style/src/main/kotlin/ktx/style/style.kt
+++ b/style/src/main/kotlin/ktx/style/style.kt
@@ -60,7 +60,8 @@ inline fun skin(atlas: TextureAtlas, init: (@SkinDsl Skin).(Skin) -> Unit = {}):
  * @return resource of the specified type with the selected name.
  * @throws GdxRuntimeException if unable to find the resource.
  */
-inline infix operator fun <reified Resource : Any> Skin.get(name: String): Resource = this[name, Resource::class.java]
+inline operator fun <reified Resource : Any> Skin.get(name: String = defaultStyle): Resource =
+    this[name, Resource::class.java]
 
 /**
  * Utility function that makes it easier to access [Skin] assets.

--- a/style/src/test/kotlin/ktx/style/styleTest.kt
+++ b/style/src/test/kotlin/ktx/style/styleTest.kt
@@ -105,7 +105,7 @@ class StyleTest {
     val skin = Skin()
     skin.add("mock", "Test.")
 
-    val infix: String = skin get "mock"
+    val infix: String = skin["mock"]
 
     infix shouldBe "Test."
   }
@@ -386,7 +386,7 @@ class StyleTest {
       }
     }
 
-    val style: ScrollPaneStyle = skin get defaultStyle
+    val style: ScrollPaneStyle = skin.get()
     assertEquals(drawable, style.background)
   }
 


### PR DESCRIPTION
Closes #188 

`Skin.get` was an infix method. I'm not sure how useful that is... why would someone choose the infix syntax over the bracket syntax? It prevented adding default parameter values so I removed it and update the tests and changelog.