### PR TITLE
Added json extensions module

### DIFF
--- a/json/README.md
+++ b/json/README.md
@@ -1,0 +1,1 @@
+# KTX: Json extensions

--- a/json/README.md
+++ b/json/README.md
@@ -1,1 +1,80 @@
 # KTX: Json extensions
+
+Extension methods for LibGDX JSON reader and writer.
+
+### Why?
+
+The JSON reader and writer in LibGDX uses a lot of `Class` parameter, which leads to a lot
+of `Type::class.java` in method arguments. Kotlin brings reified generics which create the
+possibility to get the `Class` of a generic type parameter. This module offers extension methods 
+with reified generics to avoid using `::class.java` in your code and to allow type inference and
+in some cases better type safety.
+
+### Guide
+A JSON instance can be used the same as usual, but using the extension method whenever there's
+a class parameter in the original method.
+
+##### Usage examples
+
+Creating a new JSON instance with custom parameters:
+```kotlin
+import ktx.json.*
+
+val json = Json()
+
+// Add shorthands for two classes
+json.addClassTag<Vector2>("vec2")
+json.addClassTag<Color>("color")
+
+// Set the type of elements in the "cards" collection of Player objects
+json.setElementType<Player, Card>("cards")
+
+// Add a custom serializer for Vector2
+json.setSerializer(object : Json.Serializer<Vector2>() { /* ... */ })
+```
+
+A class with a custom serializer:
+```kotlin
+import ktx.json.*
+
+class Player : Json.Serializable {
+  lateinit var pos: Vector2
+  lateinit var cards: List<Simple>
+
+  override fun read(json: Json, jsonData: JsonValue) {
+    pos = json.readValue("pos", jsonData)  // Type inference
+    cards = json.readArrayValue("cards", jsonData)  // Type inference, better type safety
+  }
+
+  override fun write(json: Json) {
+    json.writeValue("pos", pos)
+    json.writeValue("cards", cards)
+  }
+}
+```
+
+Parsing a JSON object:
+```kotlin
+import ktx.json.*
+
+val json = Json()
+val player: Player = json.fromJson("{pos:{x:10,y:10},cards:[1,2,3,5,8,13]}")
+```
+
+### Alternatives
+
+LibGDX JSON is quite limited and verbose compared to other JSON serialization libraries.
+It's a mostly untested alternative to all the other libraries around. But if your project
+is simple and you want to avoid including two JSON serialization libraries in your game
+(since it's already used for Skin parsing), LibGDX can be enough. In most cases however,
+you should probably look into other popular serialization libraries:
+
+- [kotlinx.serialization](https://github.com/Kotlin/kotlinx.serialization) provides
+reflection-free serialization to JSON, CBOR and protobuf. Serialization code is produced
+at compile time for classes marked with an annotation.
+- Many JSON libraries are already available for Java: Gson, Moshi, Jackson, org.json to name a few.
+
+
+#### Additional documentation
+
+- [Reading and writing JSON article.](https://github.com/libgdx/libgdx/wiki/Reading-and-writing-JSON)

--- a/json/build.gradle
+++ b/json/build.gradle
@@ -1,0 +1,3 @@
+dependencies {
+  provided "org.jetbrains.kotlin:kotlin-stdlib:$kotlinVersion"
+}

--- a/json/gradle.properties
+++ b/json/gradle.properties
@@ -1,0 +1,2 @@
+projectName=ktx-json
+projectDesc=LibGDX Json reader and writer utilities for Kotlin applications.

--- a/json/src/main/kotlin/ktx/json/json.kt
+++ b/json/src/main/kotlin/ktx/json/json.kt
@@ -1,0 +1,68 @@
+package ktx.json
+
+import com.badlogic.gdx.files.FileHandle
+import com.badlogic.gdx.utils.Json
+import com.badlogic.gdx.utils.JsonValue
+
+/**
+ * Parse an object of type [T] from a [file].
+ */
+inline fun <reified T> Json.fromJson(file: FileHandle) =
+        fromJson(T::class.java, file)
+
+/**
+ * Parse an object of type [T] from a [string].
+ */
+inline fun <reified T> Json.fromJson(string: String) =
+    fromJson(T::class.java, string)
+
+/**
+ * Sets a [tag] to use instead of the fully qualifier class name for type [T].
+ * This can make the JSON easier to read.
+ */
+inline fun <reified T> Json.addClassTag(tag: String) = addClassTag(tag, T::class.java)
+
+/**
+ * Returns the tag for type [T], or null if none was defined.
+ */
+inline fun <reified T> Json.getTag(): String? = getTag(T::class.java)
+
+/**
+ * Sets the elements in a collection of type [T] to type [E].
+ * When the element type is known, the class for each element in the collection
+ * does not need to be written unless different from the element type.
+ */
+inline fun <reified T, reified E> Json.setElementType(fieldName: String)  =
+    setElementType(T::class.java, fieldName, E::class.java)
+
+/**
+ * Registers a [serializer] to use for type [T] instead of the default behavior of
+ * serializing all of an object fields.
+ */
+inline fun <reified T> Json.setSerializer(serializer: Json.Serializer<T>) =
+        setSerializer(T::class.java, serializer)
+
+/**
+ * Read a value of type [T] from a [jsonData] value.
+ */
+inline fun <reified T> Json.readValue(jsonData: JsonValue): T =
+        readValue(T::class.java, jsonData)
+
+/**
+ * Read a value of type [T] from a [jsonData] attribute with a [name].
+ */
+inline fun <reified T> Json.readValue(name: String, jsonData: JsonValue): T =
+        readValue(name, T::class.java, jsonData)
+
+/**
+ * Read an iterable value of type [T] with elements of type [E] from a [jsonData] value.
+ */
+inline fun <reified T : Iterable<E>, reified E> Json.readArrayValue(jsonData: JsonValue): T =
+        readValue(T::class.java, E::class.java, jsonData)
+
+/**
+ * Read an iterable value of type [T] with elements of type [E] from a [jsonData] attribute with a [name].
+ */
+inline fun <reified T : Iterable<E>, reified E> Json.readArrayValue(name: String, jsonData: JsonValue): T =
+        readValue(name, T::class.java, E::class.java, jsonData)
+

--- a/json/src/test/kotlin/ktx/json/jsonTest.kt
+++ b/json/src/test/kotlin/ktx/json/jsonTest.kt
@@ -1,6 +1,7 @@
 package ktx.json
 
 import com.badlogic.gdx.utils.Json
+import com.badlogic.gdx.utils.JsonReader
 import com.badlogic.gdx.utils.JsonValue
 import io.kotlintest.matchers.shouldBe
 import io.kotlintest.matchers.shouldEqual
@@ -69,6 +70,44 @@ class StyleTest {
     for (i in 0 until custom1.list.size) {
       custom2.list[i].int shouldEqual custom1.list[i].int
     }
+  }
+
+  @Test
+  fun `should read and write with custom serializer`() {
+    val json = Json()
+    json.setSerializer(object : Json.Serializer<Simple> {
+      override fun read(json: Json, jsonData: JsonValue, type: Class<*>?): Simple {
+        val simple = Simple()
+        simple.int = jsonData.getInt("integer")
+        simple.str = jsonData.getString("string")
+        return simple
+      }
+
+      override fun write(json: Json, obj: Simple, knownType: Class<*>?) {
+        json.writeObjectStart()
+        json.writeValue("integer", obj.int)
+        json.writeValue("string", obj.str)
+        json.writeObjectEnd()
+      }
+    })
+
+    val simple = Simple()
+    simple.int = 12
+    simple.str = "b"
+
+    json.toJson(simple) shouldBe "{integer:12,string:b}"
+
+    val simple2: Simple = json.fromJson("{integer:31,string:c}")
+    simple2.int shouldBe 31
+    simple2.str shouldBe "c"
+  }
+
+  @Test
+  fun `should read unnamed values`() {
+    val json = Json()
+
+    json.readValue<String>(JsonReader().parse("str")) shouldBe "str"
+    json.readArrayValue<ArrayList<Int>, Int>(JsonReader().parse("[1,2,3,4,5,6]")) shouldBe arrayListOf(1, 2, 3, 4, 5, 6)
   }
 
   private class Simple {

--- a/json/src/test/kotlin/ktx/json/jsonTest.kt
+++ b/json/src/test/kotlin/ktx/json/jsonTest.kt
@@ -1,0 +1,104 @@
+package ktx.json
+
+import com.badlogic.gdx.utils.Json
+import com.badlogic.gdx.utils.JsonValue
+import io.kotlintest.matchers.shouldBe
+import io.kotlintest.matchers.shouldEqual
+import org.junit.Test
+
+/**
+ * Tests [Json] extensions.
+ */
+class StyleTest {
+
+  @Test
+  fun `should read simple object from string`() {
+    val json = Json()
+    val simple = json.fromJson<Simple>(
+        """{int:10,bool:true,str:"Hello world"}""")
+
+    simple.int shouldBe 10
+    simple.bool shouldBe true
+    simple.str shouldBe "Hello world"
+  }
+
+  @Test
+  fun `should read complex object from string`() {
+    val json = Json()
+    val complex = json.fromJson<Complex>(
+        """{bool:true,simple:{int:31,bool:true,str:"a"},list:[1,1,2,3,5,8,13]}""")
+
+    complex.bool shouldBe true
+    complex.simple.int shouldBe 31
+    complex.simple.bool shouldBe true
+    complex.simple.str shouldBe "a"
+    complex.list shouldBe listOf(1, 1, 2, 3, 5, 8, 13)
+  }
+
+  @Test
+  fun `should set and return tags`() {
+    val json = Json()
+    json.addClassTag<Simple>("simple")
+    json.addClassTag<Complex>("complex")
+
+    json.getTag<Simple>() shouldBe "simple"
+    json.getTag<Complex>() shouldBe "complex"
+  }
+
+  @Test
+  fun `should return null tag if unset`() {
+    val json = Json()
+    json.getTag<Simple>() shouldBe null
+    json.getTag<Complex>() shouldBe null
+  }
+
+  @Test
+  fun `should recreate same object`() {
+    val custom1 = Custom().apply {
+      float = 100f
+      simple = Simple().apply { int = 1 }
+      list = List(3) { Simple().apply { int = it } }
+    }
+
+    val json = Json()
+    val custom2 = json.fromJson<Custom>(json.toJson(custom1))
+
+    custom2.float shouldEqual custom1.float
+    custom2.simple.int shouldEqual custom1.simple.int
+    custom2.list.size shouldEqual custom1.list.size
+    for (i in 0 until custom1.list.size) {
+      custom2.list[i].int shouldEqual custom1.list[i].int
+    }
+  }
+
+  private class Simple {
+    var int = 0
+    var bool = false
+    var str = ""
+  }
+
+  private class Complex {
+    var bool = false
+    lateinit var simple: Simple
+    lateinit var list: List<Int>
+  }
+
+  private class Custom : Json.Serializable {
+    var float = 0f
+    lateinit var simple: Simple
+    lateinit var list: List<Simple>
+
+    override fun read(json: Json, jsonData: JsonValue) {
+      float = json.readValue("float", jsonData)
+      simple = json.readValue("simple", jsonData)
+      list = json.readArrayValue("list", jsonData)
+    }
+
+    override fun write(json: Json) {
+      json.writeValue("float", float)
+      json.writeValue("simple", simple)
+      json.writeValue("list", list)
+    }
+  }
+
+}

--- a/settings.gradle
+++ b/settings.gradle
@@ -6,6 +6,7 @@ include(
     'async',
     'box2d',
     'collections',
+    'json',
     'graphics',
     'freetype',
 //    'freetype-async',


### PR DESCRIPTION
Improves syntax with type inference and improves type safety of LibGDX Json reader and writer. The module doesn't add anything new, just reified extension function.

I didn't do the readme yet because I realized this module doesn't add any functionality apart from syntax, unlike other modules. For the same reason, only minimal tests were made.