### PR TITLE
Various updates: LibGDX, coroutines, mockito, gradle, etc

### DIFF
--- a/actors/build.gradle
+++ b/actors/build.gradle
@@ -1,4 +1,5 @@
 dependencies {
+  provided "org.jetbrains.kotlin:kotlin-stdlib:$kotlinVersion"
   testCompile "com.badlogicgames.gdx:gdx-backend-lwjgl:$gdxVersion"
   testCompile "com.badlogicgames.gdx:gdx-platform:$gdxVersion:natives-desktop"
 }

--- a/actors/src/test/kotlin/ktx/actors/stagesTest.kt
+++ b/actors/src/test/kotlin/ktx/actors/stagesTest.kt
@@ -9,10 +9,10 @@ import com.badlogic.gdx.graphics.g2d.SpriteBatch
 import com.badlogic.gdx.utils.Scaling.stretch
 import com.badlogic.gdx.utils.viewport.ScalingViewport
 import com.badlogic.gdx.utils.viewport.Viewport
-import com.nhaarman.mockito_kotlin.any
-import com.nhaarman.mockito_kotlin.doAnswer
-import com.nhaarman.mockito_kotlin.doReturn
-import com.nhaarman.mockito_kotlin.mock
+import com.nhaarman.mockitokotlin2.any
+import com.nhaarman.mockitokotlin2.doAnswer
+import com.nhaarman.mockitokotlin2.doReturn
+import com.nhaarman.mockitokotlin2.mock
 import org.junit.After
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertSame

--- a/actors/src/test/kotlin/ktx/actors/utils.kt
+++ b/actors/src/test/kotlin/ktx/actors/utils.kt
@@ -3,8 +3,8 @@ package ktx.actors
 import com.badlogic.gdx.Gdx
 import com.badlogic.gdx.scenes.scene2d.Stage
 import com.badlogic.gdx.utils.viewport.Viewport
-import com.nhaarman.mockito_kotlin.doReturn
-import com.nhaarman.mockito_kotlin.mock
+import com.nhaarman.mockitokotlin2.doReturn
+import com.nhaarman.mockitokotlin2.mock
 
 /** @return [Stage] with mocked viewport and batch. */
 internal fun getMockStage(

--- a/actors/src/test/kotlin/ktx/actors/widgetsTest.kt
+++ b/actors/src/test/kotlin/ktx/actors/widgetsTest.kt
@@ -12,11 +12,10 @@ import com.badlogic.gdx.scenes.scene2d.ui.Label
 import com.badlogic.gdx.scenes.scene2d.ui.Label.LabelStyle
 import com.badlogic.gdx.scenes.scene2d.ui.TextButton
 import com.badlogic.gdx.scenes.scene2d.ui.TextButton.TextButtonStyle
-import com.nhaarman.mockito_kotlin.mock
+import com.nhaarman.mockitokotlin2.mock
 import org.junit.Assert.assertEquals
 import org.junit.Before
 import org.junit.Test
-import com.badlogic.gdx.utils.Array as GdxArray
 
 class WidgetsTest {
   @Before

--- a/actors/src/test/kotlin/ktx/actors/widgetsTest.kt
+++ b/actors/src/test/kotlin/ktx/actors/widgetsTest.kt
@@ -24,9 +24,9 @@ class WidgetsTest {
     // constructors. Label will not successfully construct an instance without a BitmapFont.
     LwjglNativesLoader.load()
 
-    Gdx.graphics = mock<Graphics>()
-    Gdx.app = mock<Application>()
-    Gdx.gl20 = mock<GL20>()
+    Gdx.graphics = mock()
+    Gdx.app = mock()
+    Gdx.gl20 = mock()
     Gdx.files = LwjglFiles()
     Gdx.gl = Gdx.gl20
   }

--- a/app/src/main/kotlin/ktx/app/application.kt
+++ b/app/src/main/kotlin/ktx/app/application.kt
@@ -1,7 +1,6 @@
 package ktx.app
 
 import com.badlogic.gdx.ApplicationListener
-import com.badlogic.gdx.Gdx
 import com.badlogic.gdx.InputProcessor
 
 /**

--- a/app/src/test/kotlin/ktx/app/gameTest.kt
+++ b/app/src/test/kotlin/ktx/app/gameTest.kt
@@ -4,7 +4,7 @@ import com.badlogic.gdx.Gdx
 import com.badlogic.gdx.Screen
 import com.badlogic.gdx.graphics.GL20
 import com.badlogic.gdx.utils.GdxRuntimeException
-import com.nhaarman.mockito_kotlin.*
+import com.nhaarman.mockitokotlin2.*
 import org.junit.After
 import org.junit.Assert.*
 import org.junit.Before

--- a/app/src/test/kotlin/ktx/app/graphicsTest.kt
+++ b/app/src/test/kotlin/ktx/app/graphicsTest.kt
@@ -2,8 +2,8 @@ package ktx.app
 
 import com.badlogic.gdx.Gdx
 import com.badlogic.gdx.graphics.GL20
-import com.nhaarman.mockito_kotlin.mock
-import com.nhaarman.mockito_kotlin.verify
+import com.nhaarman.mockitokotlin2.mock
+import com.nhaarman.mockitokotlin2.verify
 import org.junit.Test
 
 /**

--- a/app/src/test/kotlin/ktx/app/letterboxingViewportTest.kt
+++ b/app/src/test/kotlin/ktx/app/letterboxingViewportTest.kt
@@ -2,8 +2,8 @@ package ktx.app
 
 import com.badlogic.gdx.Gdx
 import com.badlogic.gdx.backends.lwjgl.LwjglNativesLoader
-import com.nhaarman.mockito_kotlin.doReturn
-import com.nhaarman.mockito_kotlin.mock
+import com.nhaarman.mockitokotlin2.doReturn
+import com.nhaarman.mockitokotlin2.mock
 import org.junit.Assert.assertEquals
 import org.junit.Before
 import org.junit.Test

--- a/app/src/test/kotlin/ktx/app/utils.kt
+++ b/app/src/test/kotlin/ktx/app/utils.kt
@@ -1,8 +1,8 @@
 package ktx.app
 
 import com.badlogic.gdx.Graphics
-import com.nhaarman.mockito_kotlin.doReturn
-import com.nhaarman.mockito_kotlin.mock
+import com.nhaarman.mockitokotlin2.doReturn
+import com.nhaarman.mockitokotlin2.mock
 
 /**
  * @param delta time since last render.

--- a/assets/src/main/kotlin/ktx/assets/assets.kt
+++ b/assets/src/main/kotlin/ktx/assets/assets.kt
@@ -68,7 +68,7 @@ class ManagedAsset<Type>(val manager: AssetManager, val assetDescriptor: AssetDe
   override fun load() = manager.load(assetDescriptor)
   override fun unload() = manager.unload(assetDescriptor.fileName)
   override fun finishLoading() {
-    if (!isLoaded()) manager.finishLoadingAsset(assetDescriptor.fileName)
+    if (!isLoaded()) manager.finishLoadingAsset<Type>(assetDescriptor.fileName)
   }
 }
 
@@ -92,7 +92,7 @@ class DelayedAsset<Type>(val manager: AssetManager, val assetDescriptor: AssetDe
   override fun finishLoading() {
     if (!isLoaded()) {
       manager.load(assetDescriptor)
-      manager.finishLoadingAsset(assetDescriptor.fileName)
+      manager.finishLoadingAsset<Type>(assetDescriptor.fileName)
     }
   }
 }

--- a/assets/src/test/kotlin/ktx/assets/assetsTest.kt
+++ b/assets/src/test/kotlin/ktx/assets/assetsTest.kt
@@ -10,9 +10,9 @@ import com.badlogic.gdx.files.FileHandle
 import com.badlogic.gdx.utils.Array
 import com.badlogic.gdx.utils.Disposable
 import com.badlogic.gdx.utils.GdxRuntimeException
-import com.nhaarman.mockito_kotlin.doThrow
-import com.nhaarman.mockito_kotlin.mock
-import com.nhaarman.mockito_kotlin.verify
+import com.nhaarman.mockitokotlin2.doThrow
+import com.nhaarman.mockitokotlin2.mock
+import com.nhaarman.mockitokotlin2.verify
 import ktx.assets.MockAssetLoader.MockParameter
 import org.junit.Assert.*
 import org.junit.Before

--- a/assets/src/test/kotlin/ktx/assets/disposablesTest.kt
+++ b/assets/src/test/kotlin/ktx/assets/disposablesTest.kt
@@ -68,7 +68,7 @@ class DisposablesTest {
 
   @Test
   fun `should dispose iterables of assets`() {
-    val disposables = GdxArray.with(mock<Disposable>(), mock<Disposable>(), mock<Disposable>())
+    val disposables = GdxArray.with(mock<Disposable>(), mock(), mock())
 
     disposables.dispose()
 
@@ -77,7 +77,7 @@ class DisposablesTest {
 
   @Test
   fun `should ignore nulls during iterables disposing`() {
-    val disposables = GdxArray.with(mock<Disposable>(), mock<Disposable>(), null)
+    val disposables = GdxArray.with(mock<Disposable>(), mock(), null)
 
     disposables.dispose()
 
@@ -86,7 +86,7 @@ class DisposablesTest {
 
   @Test
   fun shouldSafelyDisposeIterablesOfAssets() {
-    val disposables = GdxArray.with(mock<Disposable>(), null, mock<Disposable> {
+    val disposables = GdxArray.with(mock<Disposable>(), null, mock {
       on(it.dispose()) doThrow GdxRuntimeException("Expected.")
     })
 
@@ -97,7 +97,7 @@ class DisposablesTest {
 
   @Test
   fun `should dispose iterables of assets with catch block`() {
-    val disposables = GdxArray.with(mock<Disposable>(), mock<Disposable>(), mock<Disposable>())
+    val disposables = GdxArray.with(mock<Disposable>(), mock(), mock())
 
     disposables.dispose { fail(it.message) } // Fails on unexpected exception.
 
@@ -107,7 +107,7 @@ class DisposablesTest {
   @Test
   fun `should pass exception on dispose of iterables of assets with catch block`() {
     val exception = GdxRuntimeException("Expected.")
-    val disposables = GdxArray.with(mock<Disposable>(), null, mock<Disposable> {
+    val disposables = GdxArray.with(mock<Disposable>(), null, mock {
       on(it.dispose()) doThrow exception
     })
 
@@ -118,7 +118,7 @@ class DisposablesTest {
 
   @Test
   fun `should dispose arrays of assets`() {
-    val disposables = arrayOf(mock<Disposable>(), mock<Disposable>(), mock<Disposable>())
+    val disposables = arrayOf(mock<Disposable>(), mock(), mock())
 
     disposables.dispose()
 
@@ -127,7 +127,7 @@ class DisposablesTest {
 
   @Test
   fun `should safely dispose arrays of assets`() {
-    val disposables = arrayOf(mock<Disposable>(), mock<Disposable>(), mock<Disposable> {
+    val disposables = arrayOf(mock<Disposable>(), mock(), mock {
       on(it.dispose()) doThrow GdxRuntimeException("Expected.")
     })
 
@@ -138,7 +138,7 @@ class DisposablesTest {
 
   @Test
   fun `should dispose arrays of assets with catch block`() {
-    val disposables = arrayOf(mock<Disposable>(), mock<Disposable>(), mock<Disposable>())
+    val disposables = arrayOf(mock<Disposable>(), mock(), mock())
 
     disposables.dispose { fail(it.message) } // Fails on unexpected exception.
 
@@ -148,7 +148,7 @@ class DisposablesTest {
   @Test
   fun `should pass exception on dispose of arrays of assets with catch block`() {
     val exception = GdxRuntimeException("Expected.")
-    val disposables = arrayOf(mock<Disposable>(), mock<Disposable>(), mock<Disposable> {
+    val disposables = arrayOf(mock<Disposable>(), mock(), mock {
       on(it.dispose()) doThrow exception
     })
 

--- a/assets/src/test/kotlin/ktx/assets/disposablesTest.kt
+++ b/assets/src/test/kotlin/ktx/assets/disposablesTest.kt
@@ -2,10 +2,7 @@ package ktx.assets
 
 import com.badlogic.gdx.utils.Disposable
 import com.badlogic.gdx.utils.GdxRuntimeException
-import com.nhaarman.mockito_kotlin.doThrow
-import com.nhaarman.mockito_kotlin.mock
-import com.nhaarman.mockito_kotlin.verify
-import com.nhaarman.mockito_kotlin.verifyZeroInteractions
+import com.nhaarman.mockitokotlin2.*
 import org.junit.Assert.*
 import org.junit.Test
 import com.badlogic.gdx.utils.Array as GdxArray

--- a/assets/src/test/kotlin/ktx/assets/loadersTest.kt
+++ b/assets/src/test/kotlin/ktx/assets/loadersTest.kt
@@ -1,12 +1,9 @@
 package ktx.assets
 
 import com.badlogic.gdx.assets.loaders.AssetLoader
-import com.badlogic.gdx.assets.loaders.resolvers.ClasspathFileHandleResolver
 import com.badlogic.gdx.files.FileHandle
 import com.badlogic.gdx.utils.GdxRuntimeException
-import com.nhaarman.mockito_kotlin.doReturn
-import com.nhaarman.mockito_kotlin.mock
-import com.nhaarman.mockito_kotlin.verify
+import com.nhaarman.mockitokotlin2.*
 import io.kotlintest.matchers.shouldThrow
 import ktx.assets.TextAssetLoader.TextAssetLoaderParameters
 import org.junit.Assert

--- a/async/src/main/kotlin/ktx/async/http.kt
+++ b/async/src/main/kotlin/ktx/async/http.kt
@@ -37,7 +37,7 @@ suspend fun httpRequest(
     includeCredentials: Boolean = false,
     onCancel: ((HttpRequest) -> Unit)? = null
 ): HttpRequestResult = coroutineScope {
-  suspendCancellableCoroutine<HttpRequestResult> { continuation ->
+  suspendCancellableCoroutine { continuation ->
     val httpRequest = HttpRequest(method).apply {
       this.url = url
       timeOut = timeout

--- a/async/src/main/kotlin/ktx/async/http.kt
+++ b/async/src/main/kotlin/ktx/async/http.kt
@@ -37,7 +37,7 @@ suspend fun httpRequest(
     includeCredentials: Boolean = false,
     onCancel: ((HttpRequest) -> Unit)? = null
 ): HttpRequestResult = coroutineScope {
-  suspendCancellableCoroutine { continuation ->
+  suspendCancellableCoroutine<HttpRequestResult> { continuation ->
     val httpRequest = HttpRequest(method).apply {
       this.url = url
       timeOut = timeout
@@ -45,7 +45,7 @@ suspend fun httpRequest(
       this.followRedirects = followRedirects
       this.includeCredentials = includeCredentials
       contentStream?.let { setContent(it.first, it.second) }
-      headers.forEach { header, value -> setHeader(header, value) }
+      headers.forEach { (header, value) -> setHeader(header, value) }
     }
     val listener = KtxHttpResponseListener(httpRequest, continuation, onCancel)
     Gdx.net.sendHttpRequest(httpRequest, listener)

--- a/async/src/test/kotlin/ktx/async/dispatchersTest.kt
+++ b/async/src/test/kotlin/ktx/async/dispatchersTest.kt
@@ -3,7 +3,7 @@ package ktx.async
 import com.badlogic.gdx.Gdx
 import com.badlogic.gdx.utils.Timer
 import com.badlogic.gdx.utils.async.AsyncExecutor
-import com.nhaarman.mockito_kotlin.verify
+import com.nhaarman.mockitokotlin2.verify
 import io.kotlintest.mock.mock
 import kotlinx.coroutines.Runnable
 import kotlinx.coroutines.async

--- a/async/src/test/kotlin/ktx/async/httpTest.kt
+++ b/async/src/test/kotlin/ktx/async/httpTest.kt
@@ -2,6 +2,7 @@ package ktx.async
 
 import com.badlogic.gdx.Gdx
 import com.badlogic.gdx.Net.*
+import com.badlogic.gdx.backends.lwjgl.LwjglApplicationConfiguration
 import com.badlogic.gdx.backends.lwjgl.LwjglNet
 import com.badlogic.gdx.net.HttpStatus
 import com.badlogic.gdx.utils.GdxRuntimeException
@@ -9,7 +10,7 @@ import com.badlogic.gdx.utils.async.AsyncExecutor
 import com.github.tomakehurst.wiremock.client.WireMock.aResponse
 import com.github.tomakehurst.wiremock.client.WireMock.get
 import com.github.tomakehurst.wiremock.junit.WireMockRule
-import com.nhaarman.mockito_kotlin.*
+import com.nhaarman.mockitokotlin2.*
 import io.kotlintest.matchers.shouldThrow
 import kotlinx.coroutines.CancellableContinuation
 import kotlinx.coroutines.async

--- a/async/src/test/kotlin/ktx/async/httpTest.kt
+++ b/async/src/test/kotlin/ktx/async/httpTest.kt
@@ -155,7 +155,9 @@ class AsynchronousHttpRequestsTest : AsyncTest() {
   @Test
   fun `should perform asynchronous HTTP request`() {
     // Given:
-    Gdx.net = LwjglNet()
+    Gdx.net = LwjglNet(LwjglApplicationConfiguration().apply {
+      maxNetThreads = 1
+    })
     wireMock.stubFor(get("/test").willReturn(aResponse()
         .withStatus(200)
         .withHeader("Content-Type", "text/plain")
@@ -200,7 +202,9 @@ class AsynchronousHttpRequestsTest : AsyncTest() {
   @Test
   fun `should cancel HTTP request`() {
     // Given:
-    Gdx.net = spy(LwjglNet())
+    Gdx.net = spy(LwjglNet(LwjglApplicationConfiguration().apply {
+      maxNetThreads = 1
+    }))
     wireMock.stubFor(get("/test").willReturn(aResponse()
         .withStatus(200)
         .withHeader("Content-Type", "text/plain")

--- a/box2d/src/test/kotlin/ktx/box2d/bodiesTest.kt
+++ b/box2d/src/test/kotlin/ktx/box2d/bodiesTest.kt
@@ -3,10 +3,9 @@ package ktx.box2d
 import com.badlogic.gdx.math.MathUtils
 import com.badlogic.gdx.math.Vector2
 import com.badlogic.gdx.physics.box2d.*
-import com.nhaarman.mockito_kotlin.mock
+import com.nhaarman.mockitokotlin2.mock
 import org.junit.Assert.*
 import org.junit.Test
-import com.badlogic.gdx.utils.Array as GdxArray
 
 /**
  * Tests Box2D bodies utilities and [BodyDefinition] - KTX extension of Box2D BodyDef with [FixtureDefinition] factory

--- a/build.gradle
+++ b/build.gradle
@@ -46,7 +46,7 @@ subprojects {
     provided "com.badlogicgames.gdx:gdx:$gdxVersion"
     testCompile "junit:junit:$junitVersion"
     testCompile "io.kotlintest:kotlintest:$kotlinTestVersion"
-    testCompile "com.nhaarman:mockito-kotlin-kt1.1:$kotlinMockitoVersion"
+    testCompile "com.nhaarman.mockitokotlin2:mockito-kotlin:$kotlinMockitoVersion"
     testCompile "org.jetbrains.kotlin:kotlin-stdlib:$kotlinVersion"
     testCompile "org.jetbrains.kotlin:kotlin-reflect:$kotlinVersion"
   }

--- a/collections/src/main/kotlin/ktx/collections/arrays.kt
+++ b/collections/src/main/kotlin/ktx/collections/arrays.kt
@@ -207,21 +207,21 @@ inline fun <Type> GdxArray<Type>.iterate(action: (Type, MutableIterator<Type>) -
 /**
  * Sorts elements in the array in-place descending according to their natural sort order.
  */
-fun <Type : Comparable<Type>> GdxArray<out Type>.sortDescending(): Unit {
+fun <Type : Comparable<Type>> GdxArray<out Type>.sortDescending() {
   this.sort(reverseOrder())
 }
 
 /**
  * Sorts elements in the array in-place according to natural sort order of the value returned by specified [selector] function.
  */
-inline fun <Type, R : Comparable<R>> GdxArray<out Type>.sortBy(crossinline selector: (Type) -> R?): Unit {
+inline fun <Type, R : Comparable<R>> GdxArray<out Type>.sortBy(crossinline selector: (Type) -> R?) {
   if (size > 1) this.sort(compareBy(selector))
 }
 
 /**
  * Sorts elements in the array in-place descending according to natural sort order of the value returned by specified [selector] function.
  */
-inline fun <Type, R : Comparable<R>> GdxArray<out Type>.sortByDescending(crossinline selector: (Type) -> R?): Unit {
+inline fun <Type, R : Comparable<R>> GdxArray<out Type>.sortByDescending(crossinline selector: (Type) -> R?) {
   if (size > 1) this.sort(compareByDescending(selector))
 }
 

--- a/collections/src/main/kotlin/ktx/collections/lists.kt
+++ b/collections/src/main/kotlin/ktx/collections/lists.kt
@@ -403,7 +403,7 @@ object NodePool : Pool<Node<Any>>() {
  * @return a new [PooledList] instance, which caches its nodes and iterator, and is an equivalent to java.util.LinkedList.
  * @see NodePool
  */
-fun <Type> gdxListOf(pool: Pool<Node<Type>> = NodePool.pool<Type>()): PooledList<Type> = PooledList(pool)
+fun <Type> gdxListOf(pool: Pool<Node<Type>> = NodePool.pool()): PooledList<Type> = PooledList(pool)
 
 /**
  * @param elements will be added to the list.
@@ -411,7 +411,7 @@ fun <Type> gdxListOf(pool: Pool<Node<Type>> = NodePool.pool<Type>()): PooledList
  * @return a new [PooledList] instance, which caches its nodes and iterator, and is an equivalent to java.util.LinkedList.
  * @see NodePool
  */
-fun <Type> gdxListOf(vararg elements: Type, pool: Pool<Node<Type>> = NodePool.pool<Type>()): PooledList<Type> {
+fun <Type> gdxListOf(vararg elements: Type, pool: Pool<Node<Type>> = NodePool.pool()): PooledList<Type> {
   val list = PooledList(pool)
   list.addAll(elements)
   return list

--- a/collections/src/main/kotlin/ktx/collections/lists.kt
+++ b/collections/src/main/kotlin/ktx/collections/lists.kt
@@ -422,7 +422,7 @@ fun <Type> gdxListOf(vararg elements: Type, pool: Pool<Node<Type>> = NodePool.po
  * @param pool provides and manages [Node] instances.
  * @return a new instance of [PooledList] storing the elements from the iterable.
  */
-fun <Type> Iterable<Type>.toGdxList(pool: Pool<Node<Type>> = NodePool.pool<Type>()): PooledList<Type> {
+fun <Type> Iterable<Type>.toGdxList(pool: Pool<Node<Type>> = NodePool.pool()): PooledList<Type> {
   val list = PooledList(pool)
   list.addAll(this)
   return list
@@ -433,7 +433,7 @@ fun <Type> Iterable<Type>.toGdxList(pool: Pool<Node<Type>> = NodePool.pool<Type>
  * @param pool provides and manages [Node] instances.
  * @return a new instance of [PooledList] storing the elements from the array.
  */
-fun <Type> Array<out Type>.toGdxList(pool: Pool<Node<Type>> = NodePool.pool<Type>()): PooledList<Type> {
+fun <Type> Array<out Type>.toGdxList(pool: Pool<Node<Type>> = NodePool.pool()): PooledList<Type> {
   val list = PooledList(pool)
   list.addAll(this)
   return list

--- a/collections/src/main/kotlin/ktx/collections/maps.kt
+++ b/collections/src/main/kotlin/ktx/collections/maps.kt
@@ -185,7 +185,7 @@ operator fun <Key, Value> IdentityMap<Key, Value>.set(key: Key, value: Value): V
  * @param action will be invoked on each key and value pair. Passed iterator is ensured to be the same instance throughout
  *    the iteration. It can be used to remove elements.
  */
-inline fun <Key, Value> IdentityMap<Key, Value>.iterate(action: (Key, Value, MutableIterator<IdentityMap.Entry<Key, Value>>) -> Unit) {
+inline fun <Key, Value> IdentityMap<Key, Value>.iterate(action: (Key, Value, MutableIterator<Entry<Key, Value>>) -> Unit) {
   val iterator = this.iterator()
   while (iterator.hasNext()) {
     val next = iterator.next()
@@ -283,18 +283,6 @@ inline operator fun <Key, Value> ObjectMap.Entry<Key, Value>.component1() = key!
  * @return [ObjectMap.Entry.value]
  */
 inline operator fun <Key, Value> ObjectMap.Entry<Key, Value>.component2(): Value? = value
-
-/**
- * Allows to destruct [IdentityMap.Entry] into key and value components.
- * @return [IdentityMap.Entry.key]
- */
-inline operator fun <Key, Value> IdentityMap.Entry<Key, Value>.component1() = key!!
-
-/**
- * Allows to destruct [IdentityMap.Entry] into key and value components. Nullable, since [IdentityMap] allows null values.
- * @return [IdentityMap.Entry.value]
- */
-inline operator fun <Key, Value> IdentityMap.Entry<Key, Value>.component2(): Value? = value
 
 /**
  * Allows to destruct [IntMap.Entry] into key and value components.

--- a/collections/src/main/kotlin/ktx/collections/sets.kt
+++ b/collections/src/main/kotlin/ktx/collections/sets.kt
@@ -3,7 +3,6 @@
 package ktx.collections
 
 import com.badlogic.gdx.utils.IntSet
-import com.badlogic.gdx.utils.ObjectMap
 import com.badlogic.gdx.utils.ObjectSet
 
 /** Alias for [com.badlogic.gdx.utils.ObjectSet]. Added for consistency with other collections and factory methods. */

--- a/collections/src/test/kotlin/ktx/collections/mapsTest.kt
+++ b/collections/src/test/kotlin/ktx/collections/mapsTest.kt
@@ -274,18 +274,6 @@ class MapsTest {
   }
 
   @Test
-  fun `should destruct IdentityMap#Entry into key and value`() {
-    val entry = IdentityMap.Entry<String, String>()
-    entry.key = "Key"
-    entry.value = "Value"
-
-    val (key, value) = entry
-
-    assertEquals("Key", key)
-    assertEquals("Value", value)
-  }
-
-  @Test
   fun `should destruct IntMap#Entry into key and value`() {
     val entry = IntMap.Entry<String>()
     entry.key = 10

--- a/freetype-async/src/test/kotlin/ktx/freetype/async/freetypeAsyncTest.kt
+++ b/freetype-async/src/test/kotlin/ktx/freetype/async/freetypeAsyncTest.kt
@@ -8,7 +8,7 @@ import com.badlogic.gdx.graphics.g2d.BitmapFont
 import com.badlogic.gdx.graphics.g2d.freetype.FreeTypeFontGenerator
 import com.badlogic.gdx.graphics.g2d.freetype.FreeTypeFontGeneratorLoader
 import com.badlogic.gdx.graphics.g2d.freetype.FreetypeFontLoader
-import com.nhaarman.mockito_kotlin.mock
+import com.nhaarman.mockitokotlin2.mock
 import ktx.async.`coroutine test`
 import ktx.async.`destroy coroutines context`
 import ktx.async.assets.AssetStorage

--- a/freetype/src/test/kotlin/ktx/freetype/freetypeTest.kt
+++ b/freetype/src/test/kotlin/ktx/freetype/freetypeTest.kt
@@ -9,7 +9,7 @@ import com.badlogic.gdx.graphics.g2d.BitmapFont
 import com.badlogic.gdx.graphics.g2d.freetype.FreeTypeFontGenerator
 import com.badlogic.gdx.graphics.g2d.freetype.FreeTypeFontGeneratorLoader
 import com.badlogic.gdx.graphics.g2d.freetype.FreetypeFontLoader
-import com.nhaarman.mockito_kotlin.mock
+import com.nhaarman.mockitokotlin2.mock
 import org.junit.After
 import org.junit.Assert.*
 import org.junit.Before

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,7 +1,7 @@
 libGroup=io.github.libktx
 gdxVersion=1.9.9
-kotlinVersion=1.3.31
-kotlinCoroutinesVersion=1.2.1
+kotlinVersion=1.3.41
+kotlinCoroutinesVersion=1.3.0-RC
 
 ashleyVersion=1.7.3
 visUiVersion=1.4.2

--- a/gradle.properties
+++ b/gradle.properties
@@ -4,18 +4,18 @@ kotlinVersion=1.3.41
 kotlinCoroutinesVersion=1.3.0-RC
 
 ashleyVersion=1.7.3
-visUiVersion=1.4.2
+visUiVersion=1.4.3
 
-spekVersion=1.1.5
+spekVersion=1.2.1
 kotlinTestVersion=2.0.7
 kotlinMockitoVersion=2.1.0
 assertjVersion=3.11.1
 junitVersion=4.12
 junitPlatformVersion=1.2.0
-slf4jVersion=1.7.25
-wireMockVersion=2.21.0
+slf4jVersion=1.7.26
+wireMockVersion=2.24.0
 
-dokkaVersion=0.9.17
+dokkaVersion=0.9.18
 nexusPluginVersion=0.5.3
 configurationsPluginVersion=3.0.3
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -8,7 +8,7 @@ visUiVersion=1.4.2
 
 spekVersion=1.1.5
 kotlinTestVersion=2.0.7
-kotlinMockitoVersion=1.6.0
+kotlinMockitoVersion=2.1.0
 assertjVersion=3.11.1
 junitVersion=4.12
 junitPlatformVersion=1.2.0

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,5 @@
 libGroup=io.github.libktx
-gdxVersion=1.9.9
+gdxVersion=1.9.10
 kotlinVersion=1.3.41
 kotlinCoroutinesVersion=1.3.0-RC
 

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-5.0-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-5.5.1-all.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/graphics/src/test/kotlin/ktx/graphics/graphicsTest.kt
+++ b/graphics/src/test/kotlin/ktx/graphics/graphicsTest.kt
@@ -3,9 +3,7 @@ package ktx.graphics
 import com.badlogic.gdx.graphics.Color
 import com.badlogic.gdx.graphics.g2d.Batch
 import com.badlogic.gdx.graphics.glutils.ShaderProgram
-import com.nhaarman.mockito_kotlin.mock
-import com.nhaarman.mockito_kotlin.never
-import com.nhaarman.mockito_kotlin.verify
+import com.nhaarman.mockitokotlin2.*
 import org.junit.Assert.*
 import org.junit.Test
 

--- a/graphics/src/test/kotlin/ktx/graphics/shapeRendererTest.kt
+++ b/graphics/src/test/kotlin/ktx/graphics/shapeRendererTest.kt
@@ -5,9 +5,7 @@ import com.badlogic.gdx.graphics.glutils.ShapeRenderer
 import com.badlogic.gdx.graphics.glutils.ShapeRenderer.ShapeType
 import com.badlogic.gdx.math.Vector2
 import com.badlogic.gdx.math.Vector3
-import com.nhaarman.mockito_kotlin.mock
-import com.nhaarman.mockito_kotlin.never
-import com.nhaarman.mockito_kotlin.verify
+import com.nhaarman.mockitokotlin2.*
 import org.junit.Assert
 import org.junit.Test
 

--- a/inject/src/test/kotlin/ktx/inject/injectTest.kt
+++ b/inject/src/test/kotlin/ktx/inject/injectTest.kt
@@ -301,7 +301,7 @@ class DependencyInjectionTest {
 
   @Test
   fun `should dispose of Disposable components with error handling`() {
-    Gdx.app = mock<Application>()
+    Gdx.app = mock()
     val singleton = mock<Disposable> {
       on(it.dispose()) doThrow GdxRuntimeException("Expected.")
     }

--- a/inject/src/test/kotlin/ktx/inject/injectTest.kt
+++ b/inject/src/test/kotlin/ktx/inject/injectTest.kt
@@ -4,7 +4,7 @@ import com.badlogic.gdx.Application
 import com.badlogic.gdx.Gdx
 import com.badlogic.gdx.utils.Disposable
 import com.badlogic.gdx.utils.GdxRuntimeException
-import com.nhaarman.mockito_kotlin.*
+import com.nhaarman.mockitokotlin2.*
 import org.junit.After
 import org.junit.Assert.*
 import org.junit.Test

--- a/inject/src/test/kotlin/ktx/inject/injectTest.kt
+++ b/inject/src/test/kotlin/ktx/inject/injectTest.kt
@@ -1,6 +1,5 @@
 package ktx.inject
 
-import com.badlogic.gdx.Application
 import com.badlogic.gdx.Gdx
 import com.badlogic.gdx.utils.Disposable
 import com.badlogic.gdx.utils.GdxRuntimeException

--- a/scene2d/src/main/kotlin/ktx/scene2d/group.kt
+++ b/scene2d/src/main/kotlin/ktx/scene2d/group.kt
@@ -31,7 +31,7 @@ inline fun verticalGroup(
  * @return a new [Container] instance.
  */
 inline fun container(
-    init: KContainer<Actor>.() -> Unit = {}) = actor(KContainer<Actor>(), init)
+    init: KContainer<Actor>.() -> Unit = {}) = actor(KContainer(), init)
 
 /**
  * @param vertical true to make the widget vertical, false to make it horizontal. Defaults to false (horizontal).

--- a/scene2d/src/main/kotlin/ktx/scene2d/widget.kt
+++ b/scene2d/src/main/kotlin/ktx/scene2d/widget.kt
@@ -248,7 +248,7 @@ interface KTree : KWidget<KNode> {
     icon?.let { node.icon = icon }
     expanded?.let { node.isExpanded = expanded }
     selectable?.let { node.isSelectable = selectable }
-    node.`object` = userObject
+    node.value = userObject
     return this
   }
 
@@ -342,7 +342,7 @@ class KListWidget<T>(skin: Skin, style: String) : com.badlogic.gdx.scenes.scene2
 
 /** Extends [Tree] [Node] API with type-safe widget builders. */
 @Scene2dDsl
-class KNode(actor: Actor) : Node(actor), KTree {
+class KNode(actor: Actor) : Node<Node<*, *, *>, Any?, Actor>(actor), KTree {
   override fun add(actor: Actor): KNode {
     val node = KNode(actor)
     add(node)
@@ -418,7 +418,7 @@ class KTextButton(text: String, skin: Skin, style: String) : TextButton(text, sk
 
 /** Extends [Tree] API with type-safe widget builders. */
 @Scene2dDsl
-class KTreeWidget(skin: Skin, style: String) : Tree(skin, style), KTree {
+class KTreeWidget(skin: Skin, style: String) : Tree<Node<*, *, *>, Any?>(skin, style), KTree {
   override fun add(actor: Actor): KNode {
     val node = KNode(actor)
     add(node)

--- a/scene2d/src/test/kotlin/ktx/scene2d/factoryTest.kt
+++ b/scene2d/src/test/kotlin/ktx/scene2d/factoryTest.kt
@@ -8,7 +8,6 @@ import com.badlogic.gdx.scenes.scene2d.ui.Tree.Node
 import com.kotcrab.vis.ui.VisUI
 import org.junit.Assert.*
 import org.junit.Test
-import com.badlogic.gdx.scenes.scene2d.ui.List as ListWidget
 import com.badlogic.gdx.utils.Array as GdxArray
 
 /**

--- a/scene2d/src/test/kotlin/ktx/scene2d/testUtilities.kt
+++ b/scene2d/src/test/kotlin/ktx/scene2d/testUtilities.kt
@@ -4,7 +4,7 @@ import com.badlogic.gdx.Gdx
 import com.badlogic.gdx.backends.lwjgl.LwjglFiles
 import com.badlogic.gdx.backends.lwjgl.LwjglNativesLoader
 import com.kotcrab.vis.ui.VisUI
-import com.nhaarman.mockito_kotlin.mock
+import com.nhaarman.mockitokotlin2.mock
 import org.junit.AfterClass
 import org.junit.Before
 import org.junit.BeforeClass

--- a/scene2d/src/test/kotlin/ktx/scene2d/widgetTest.kt
+++ b/scene2d/src/test/kotlin/ktx/scene2d/widgetTest.kt
@@ -169,7 +169,7 @@ class KTreeTest : NeedsLibGDX() {
     val group = TestTree()
     val actor = Actor()
 
-    val result: Node = group.storeActor(actor)
+    val result: Node<*, *, *> = group.storeActor(actor)
 
     assertTrue(actor in group.children)
     assertSame(actor, result.actor)
@@ -203,11 +203,11 @@ class KTreeTest : NeedsLibGDX() {
       assertSame(icon, node.icon)
       assertFalse(node.isSelectable)
       assertTrue(node.isExpanded)
-      assertEquals("Test", node.`object`)
+      assertEquals("Test", node.value)
     }
   }
 
-  class TestTree : Tree(VisUI.getSkin()), KTree {
+  class TestTree : Tree<Node<*, *, *>, Any?>(VisUI.getSkin()), KTree {
     override fun add(actor: Actor): KNode {
       val node = KNode(actor)
       add(node)

--- a/vis-style/src/test/kotlin/ktx/style/visStyleTest.kt
+++ b/vis-style/src/test/kotlin/ktx/style/visStyleTest.kt
@@ -27,7 +27,7 @@ import com.kotcrab.vis.ui.widget.color.ColorPickerWidgetStyle
 import com.kotcrab.vis.ui.widget.spinner.Spinner.SpinnerStyle
 import com.kotcrab.vis.ui.widget.tabbedpane.TabbedPane.TabbedPaneStyle
 import com.kotcrab.vis.ui.widget.toast.Toast.ToastStyle
-import com.nhaarman.mockito_kotlin.mock
+import com.nhaarman.mockitokotlin2.mock
 import org.junit.Assert.assertEquals
 import org.junit.Test
 

--- a/vis/src/main/kotlin/ktx/vis/widgetFactory.kt
+++ b/vis/src/main/kotlin/ktx/vis/widgetFactory.kt
@@ -416,7 +416,7 @@ interface TreeWidgetFactory : WidgetFactory<KNode> {
     icon?.let { node.icon = icon }
     expanded?.let { node.isExpanded = expanded }
     selectable?.let { node.isSelectable = selectable }
-    node.`object` = userObject
+    node.value = userObject
     return this
   }
 

--- a/vis/src/main/kotlin/ktx/vis/widgetFactory.kt
+++ b/vis/src/main/kotlin/ktx/vis/widgetFactory.kt
@@ -206,7 +206,7 @@ interface WidgetFactory<S> {
       = actor(MultiSplitPane(vertical, styleName), init)
 
   /** @see [Container] */
-  fun <T : Actor> container(actor: T? = null, init: (@VisDsl Container<T>).(S) -> Unit = {}): Container<T> = actor(Container(actor), init)
+  fun <T : Actor> container(actor: T? = null, init: (@VisDsl Container<T>).(S) -> Unit = {}): Container<T> = actor(Container<T>(actor), init)
 
   /** @see [CollapsibleWidget] */
   fun collapsible(table: Table, init: (@VisDsl CollapsibleWidget).(S) -> Unit = {}): CollapsibleWidget = actor(CollapsibleWidget(table), init)

--- a/vis/src/main/kotlin/ktx/vis/widgetFactory.kt
+++ b/vis/src/main/kotlin/ktx/vis/widgetFactory.kt
@@ -43,7 +43,7 @@ interface WidgetFactory<S> {
   fun image(drawableName: String, init: (@VisDsl VisImage).(S) -> Unit = {}): VisImage = actor(VisImage(drawableName), init)
 
   /** @see [VisList] */
-  fun <T> list(styleName: String = DEFAULT_STYLE, init: (@VisDsl VisList<T>).(S) -> Unit = {}): VisList<T> = actor(VisList<T>(styleName), init)
+  fun <T> list(styleName: String = DEFAULT_STYLE, init: (@VisDsl VisList<T>).(S) -> Unit = {}): VisList<T> = actor(VisList(styleName), init)
 
   /** @see [VisProgressBar] */
   fun progressBar(min: Float = 0f, max: Float = 100f, step: Float = 1f, vertical: Boolean = false, init: (@VisDsl VisProgressBar).(S) -> Unit = {}): VisProgressBar
@@ -56,7 +56,7 @@ interface WidgetFactory<S> {
 
   /** @see [VisSelectBox] */
   fun <T> selectBox(styleName: String = DEFAULT_STYLE, init: (@VisDsl VisSelectBox<T>).(S) -> Unit = {}): VisSelectBox<T>
-      = actor(VisSelectBox<T>(styleName), init)
+      = actor(VisSelectBox(styleName), init)
 
   /** @see [VisSlider] */
   fun slider(min: Float = 0f, max: Float = 100f, step: Float = 1f, vertical: Boolean = false, init: (@VisDsl VisSlider).(S) -> Unit = {}): VisSlider
@@ -206,7 +206,7 @@ interface WidgetFactory<S> {
       = actor(MultiSplitPane(vertical, styleName), init)
 
   /** @see [Container] */
-  fun <T : Actor> container(actor: T? = null, init: (@VisDsl Container<T>).(S) -> Unit = {}): Container<T> = actor(Container<T>(actor), init)
+  fun <T : Actor> container(actor: T? = null, init: (@VisDsl Container<T>).(S) -> Unit = {}): Container<T> = actor(Container(actor), init)
 
   /** @see [CollapsibleWidget] */
   fun collapsible(table: Table, init: (@VisDsl CollapsibleWidget).(S) -> Unit = {}): CollapsibleWidget = actor(CollapsibleWidget(table), init)

--- a/vis/src/main/kotlin/ktx/vis/widgets.kt
+++ b/vis/src/main/kotlin/ktx/vis/widgets.kt
@@ -104,7 +104,7 @@ class KVisTree(styleName: String) : VisTree(styleName), TreeWidgetFactory {
 
 /** Extends [Tree] [Node] API with type-safe widget builders. */
 @VisDsl
-class KNode(actor: Actor) : Node(actor), TreeWidgetFactory {
+class KNode(actor: Actor) : Node<Node<*, *, *>, Any?, Actor>(actor), TreeWidgetFactory {
   override fun <T : Actor> addActorToTree(actor: T): KNode {
     val node = KNode(actor)
     add(node)

--- a/vis/src/test/kotlin/ktx/vis/needsLibgdx.kt
+++ b/vis/src/test/kotlin/ktx/vis/needsLibgdx.kt
@@ -3,7 +3,6 @@ package ktx.vis
 import com.badlogic.gdx.Gdx
 import com.badlogic.gdx.backends.lwjgl.LwjglFiles
 import com.badlogic.gdx.backends.lwjgl.LwjglNativesLoader
-import com.badlogic.gdx.graphics.GL20
 import com.kotcrab.vis.ui.VisUI
 import com.nhaarman.mockito_kotlin.mock
 
@@ -18,7 +17,7 @@ abstract class NeedsLibGDX {
 
       Gdx.graphics = mock()
       Gdx.app = mock()
-      Gdx.gl = mock<GL20>()
+      Gdx.gl = mock()
       Gdx.files = LwjglFiles()
       Gdx.gl20 = Gdx.gl
 

--- a/vis/src/test/kotlin/ktx/vis/needsLibgdx.kt
+++ b/vis/src/test/kotlin/ktx/vis/needsLibgdx.kt
@@ -4,7 +4,7 @@ import com.badlogic.gdx.Gdx
 import com.badlogic.gdx.backends.lwjgl.LwjglFiles
 import com.badlogic.gdx.backends.lwjgl.LwjglNativesLoader
 import com.kotcrab.vis.ui.VisUI
-import com.nhaarman.mockito_kotlin.mock
+import com.nhaarman.mockitokotlin2.mock
 
 /**
  * Tests that require to have mocked libGDX environment must inherit from this class.

--- a/vis/src/test/kotlin/ktx/vis/widgetsTest.kt
+++ b/vis/src/test/kotlin/ktx/vis/widgetsTest.kt
@@ -275,7 +275,7 @@ class KTreeTest : NeedsLibGDX() {
   fun `should add widget to group and return its cell`() {
     val group = KVisTree("default")
     val actor = Actor()
-    val result: Node = group.addActorToTree(actor)
+    val result: Node<*, *, *> = group.addActorToTree(actor)
     assertTrue(actor in group.children)
     assertSame(actor, result.actor)
   }
@@ -305,7 +305,7 @@ class KTreeTest : NeedsLibGDX() {
       assertSame(icon, node.icon)
       assertFalse(node.isSelectable)
       assertTrue(node.isExpanded)
-      assertEquals("Test", node.`object`)
+      assertEquals("Test", node.value)
     }
   }
 }


### PR DESCRIPTION
LibGDX 1.9.10 was released a few days ago with a few changes. I took the opportunity to also update the kotlin version to 1.3.41 and the coroutines to a version that matched the kotlin version. I also updated a few testing frameworks, I hope you don't mind.

All tests pass. There might some changes to do with the new `Tree.Node` generics since `KNode` hides them for now.