### PR TITLE
SequenceAction and ParallelAction functions refactoring

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,8 @@
 #### 1.9.10-SNAPSHOT
-- **[CHANGE]** `Action.parallelTo` changed to `Action.along` and it now mutates the caller and argument if they are ParallelActions, to save wasted instantiations and avoid GC.
+- **[CHANGE]** `Action.parallelTo` changed to `Action.along`.
+- **[CHANGE]** `Action.along` (formerly `Action.parallelTo`) and `Action.then` no longer unwrap the second action.
+- **[CHANGE]** `ParallelAction.along` (formerly `ParallelAction.parallelTo`) and `SequenceAction.then` simply add the second action to the group without unwrapping.
 - **[UPDATE]** Added `/` operator to Action, which performs the non-mutating version of along, wrapping the caller and argument in a new ParallelAction.
-- **[CHANGE]** `Action.then` now mutates the caller and argument if they are SequenceActions, to save wasted instantiations and avoid GC. The `+` operator still performs the old non-mutating version, wrapping the caller and argument in a new SequenceAction.
 - **[CHANGE]** `ParallelAction.plus()` and `SequenceAction.plus()` no longer unwrap their components.
 
 #### 1.9.10-b1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,7 @@
 #### 1.9.10-SNAPSHOT
+- **[CHANGE]** `Action.parallelTo` changed to `Action.along` and it now mutates the caller and argument if they are ParallelActions, to save wasted instantiations and avoid GC.
+- **[UPDATE]** Added `/` operator to Action, which performs the non-mutating version of along, wrapping the caller and argument in a new ParallelAction.
+- **[CHANGE]** `Action.then` now mutates the caller and argument if they are SequenceActions, to save wasted instantiations and avoid GC. The `+` operator still performs the old non-mutating version, wrapping the caller and argument in a new SequenceAction.
 
 #### 1.9.10-b1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 - **[CHANGE]** `Action.parallelTo` changed to `Action.along` and it now mutates the caller and argument if they are ParallelActions, to save wasted instantiations and avoid GC.
 - **[UPDATE]** Added `/` operator to Action, which performs the non-mutating version of along, wrapping the caller and argument in a new ParallelAction.
 - **[CHANGE]** `Action.then` now mutates the caller and argument if they are SequenceActions, to save wasted instantiations and avoid GC. The `+` operator still performs the old non-mutating version, wrapping the caller and argument in a new SequenceAction.
+- **[CHANGE]** `ParallelAction.plus()` and `SequenceAction.plus()` no longer unwrap their components.
 
 #### 1.9.10-b1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,15 +1,14 @@
 #### 1.9.10-SNAPSHOT
-- **[CHANGE]** `Action.parallelTo` changed to `Action.along`.
-- **[CHANGE]** `Action.along` (formerly `Action.parallelTo`) and `Action.then` no longer unwrap the second action.
-- **[CHANGE]** `ParallelAction.along` (formerly `ParallelAction.parallelTo`) and `SequenceAction.then` simply add the second action to the group without unwrapping.
-- **[UPDATE]** Added `/` operator to Action, which performs the non-mutating version of along, wrapping the caller and argument in a new ParallelAction.
-- **[CHANGE]** `ParallelAction.plus()` and `SequenceAction.plus()` no longer unwrap their components.
-
 - **[UPDATE]** Updated to Kotlin 1.3.50.
 - **[UPDATE]** Updated to Kotlin Coroutines 1.3.0.
 - **[CHANGE]** (`ktx-box2d`) Added `disposeOfShape` parameters to `fixture` extension methods of `Body` and `BodyDefinition`.
 Setting these values to `true` will cause the fixture shapes to be immediately disposed of after `Fixture` construction.
 - **[FIX]** (`ktx-box2d`) Removed memory leak caused by undisposed shapes.
+- **[CHANGE]** `Action.parallelTo` changed to `Action.along`.
+- **[CHANGE]** `Action.along` (formerly `Action.parallelTo`) and `Action.then` no longer unwrap the second action.
+- **[CHANGE]** `ParallelAction.along` (formerly `ParallelAction.parallelTo`) and `SequenceAction.then` simply add the second action to the group without unwrapping.
+- **[FEATURE]** Added `/` operator to Action, which performs the non-mutating version of along, wrapping the caller and argument in a new ParallelAction.
+- **[CHANGE]** `ParallelAction.plus()` and `SequenceAction.plus()` no longer unwrap their components.
 
 #### 1.9.10-b1
 

--- a/actors/README.md
+++ b/actors/README.md
@@ -44,11 +44,11 @@ be enough for most use cases.
 
 - Global actions can be added and removed from `Stage` with `+=` and `-=` operators.
 - Actions can be added and removed to individual `Actor` instances with `+=` and `-=` operators.
-- `Action.then` *infix* extension function allows easy creation of action sequences with pleasant syntax.
-- `Action.along` *infix* extension function allows easy creation of parallel actions with pleasant syntax.
-- `+` operator can be used to create action sequences (alternative non-mutating version of `then`).
-- `/` operator can be used combine actions in parallel (alternative non-mutating version of `along`).
-- `+=` operator allows to add an action to an existing `SequenceAction` or `ParallelAction`.
+- `Action.then` *infix* extension function allows easy creation of action sequences with pleasant syntax. Either wraps the two actions in a SequenceAction, or if the left action is already a SequenceAction, adds the right action to it so long chains result in a single SequenceAction.
+- `Action.along` *infix* extension function allows easy creation of parallel actions with pleasant syntax. Either wraps the two actions in a SequenceAction, or if the left action is already a ParallelAction, adds the right action to it so long chains result in a single ParallelAction.
+- `+` operator can be used to create action sequences (alternative to `then`). The operator is non-mutating, so it wraps the two actions every time. For long chains, the `then` function may be preferred to avoid creating multiple nested SequenceActions.
+- `/` operator can be used combine actions in parallel (alternative to `along`). The operator is non-mutating, so it wraps the two actions every time. For long chains, the `along` function may be preferred to avoid creating multiple nested ParallelActions.
+- `+=` operator adds an action to an existing `SequenceAction` or `ParallelAction`.
 
 #### Widgets
 
@@ -179,11 +179,12 @@ Chaining actions with infix `then` function (`SequenceAction` utility) and infix
 import ktx.actors.*
 import com.badlogic.gdx.scenes.scene2d.actions.Actions.*
 
-val sequence = alpha(0f) then fadeIn(1f) then delay(1f) then fadeOut(1f)
+val sequence = alpha(0f) then fadeIn(1f) then delay(1f) then fadeOut(1f) 
 actor += sequence // Adding action to the actor.
+val parallel = fadeTo(0f) along scaleTo(0f, 0f) along moveTo(0f, 0f) // wrap three actions in ParallelAction
 ```
 
-Chaining actions with `+` operator (`SequenceAction` utility):
+Chaining actions with `+` operator (`SequenceAction` utility) and `/` operator (`ParallelAction` utility):
 
 ```Kotlin
 import ktx.actors.*
@@ -191,6 +192,7 @@ import com.badlogic.gdx.scenes.scene2d.actions.Actions.*
 
 val sequence = alpha(0f) + fadeIn(1f) + delay(1f) + fadeOut(1f)
 actor += sequence // Adding action to the actor.
+val parallel = fadeTo(0f) / scaleTo(0f, 0f) / moveTo(0f, 0f) // wrap three actions in ParallelAction
 ```
 
 Adding and removing actions to stages and actors with operators:

--- a/actors/README.md
+++ b/actors/README.md
@@ -44,10 +44,11 @@ be enough for most use cases.
 
 - Global actions can be added and removed from `Stage` with `+=` and `-=` operators.
 - Actions can be added and removed to individual `Actor` instances with `+=` and `-=` operators.
-- `Action.then` *infix* extension function allows to easily create action sequences with pleasant syntax.
-- `Action.parallelTo` *infix* extension function allows to easily create parallel actions with pleasant syntax.
-- `+` operator can be used to create action sequences (alternative syntax to `then`).
-- `+=` operator allows to add an action to an existing `SequenceAction`.
+- `Action.then` *infix* extension function allows easy creation of action sequences with pleasant syntax.
+- `Action.along` *infix* extension function allows easy creation of parallel actions with pleasant syntax.
+- `+` operator can be used to create action sequences (alternative non-mutating version of `then`).
+- `/` operator can be used combine actions in parallel (alternative non-mutating version of `along`).
+- `+=` operator allows to add an action to an existing `SequenceAction` or `ParallelAction`.
 
 #### Widgets
 
@@ -173,8 +174,7 @@ textField.onKeyboardFocusEvent { focusEvent, actor ->
 }
 ```
 
-Chaining actions with infix `then` function (`SequenceAction` utility):
-
+Chaining actions with infix `then` function (`SequenceAction` utility) and infix `along` function
 ```Kotlin
 import ktx.actors.*
 import com.badlogic.gdx.scenes.scene2d.actions.Actions.*

--- a/actors/src/main/kotlin/ktx/actors/actions.kt
+++ b/actors/src/main/kotlin/ktx/actors/actions.kt
@@ -33,7 +33,7 @@ operator fun Actor.plusAssign(action: Action) = addAction(action)
 operator fun Actor.minusAssign(action: Action) = removeAction(action)
 
 /**
- * Combines this action and the passed action into a single [SequenceAction].
+ * Wraps this action and the passed action in a [SequenceAction].
  *
  * @param action will be executed after this action.
  * @return [SequenceAction] storing both actions.
@@ -60,7 +60,8 @@ infix fun SequenceAction.then(action: Action): SequenceAction {
 operator fun Action.plus(action: Action): SequenceAction = then(action)
 
 /**
- * Adds another [Action] to this sequence.
+ * Adds [action] to this [SequenceAction].
+ *
  * @param action will be executed during this sequence.
  */
 operator fun SequenceAction.plusAssign(action: Action) = addAction(action)
@@ -77,8 +78,8 @@ infix fun Action.along(action: Action): ParallelAction = Actions.parallel(this, 
 infix fun Action.parallelTo(action: Action): ParallelAction = along(action)
 
 /**
- * Adds [action] to this [ParallelAction], so long as it isn't a [SequenceAction]. If it is a [SequenceAction], see
- * [Action.along].
+ * Adds [action] to this [ParallelAction], so long as this isn't a [SequenceAction]. If it is a [SequenceAction],
+ * [@see Action.along].
  *
  * @param action will be added to this [ParallelAction].
  * @return [ParallelAction] this [ParallelAction], now containing [action]]
@@ -102,7 +103,7 @@ infix fun ParallelAction.parallelTo(action: Action): ParallelAction = along(acti
 operator fun Action.div(action: Action): ParallelAction = along(action)
 
 /**
- * Adds another [Action] to this action group.
+ * Adds another [Action] to this [ParallelAction].
  * @param action will be executed in parallel to the other actions of this [ParallelAction].
  */
 operator fun ParallelAction.plusAssign(action: Action) = addAction(action)

--- a/actors/src/main/kotlin/ktx/actors/actions.kt
+++ b/actors/src/main/kotlin/ktx/actors/actions.kt
@@ -46,9 +46,8 @@ infix fun Action.then(action: Action): SequenceAction = Actions.sequence(this, a
  * @param action will be added to this [SequenceAction]
  * @return [SequenceAction] this [SequenceAction]
  */
-infix fun SequenceAction.then(action: Action): SequenceAction {
+infix fun SequenceAction.then(action: Action): SequenceAction = apply{
   addAction(action)
-  return this
 }
 
 /**
@@ -57,7 +56,7 @@ infix fun SequenceAction.then(action: Action): SequenceAction {
  * @param action will be executed after [this] action.
  * @return [SequenceAction] storing both actions.
  */
-operator fun Action.plus(action: Action): SequenceAction = then(action)
+operator fun Action.plus(action: Action): SequenceAction = Actions.sequence(this, action)
 
 /**
  * Adds [action] to this [SequenceAction].
@@ -85,8 +84,10 @@ infix fun Action.parallelTo(action: Action): ParallelAction = along(action)
  * @return [ParallelAction] this [ParallelAction], now containing [action]]
  */
 infix fun ParallelAction.along(action: Action): ParallelAction {
-  if (this is SequenceAction)
-    return this as Action along action // workaround for SequenceAction inheritance from ParallelAction
+  if (this is SequenceAction) {
+    // Workaround for SequenceAction inheritance from ParallelAction:
+    return Actions.parallel(this, action)
+  }
   addAction(action)
   return this
 }
@@ -100,7 +101,7 @@ infix fun ParallelAction.parallelTo(action: Action): ParallelAction = along(acti
  * @param action will be executed at the same time as this action.
  * @return [SequenceAction] storing both actions.
  */
-operator fun Action.div(action: Action): ParallelAction = along(action)
+operator fun Action.div(action: Action): ParallelAction = Actions.parallel(this, action)
 
 /**
  * Adds another [Action] to this [ParallelAction].

--- a/actors/src/test/kotlin/ktx/actors/actionsTest.kt
+++ b/actors/src/test/kotlin/ktx/actors/actionsTest.kt
@@ -86,36 +86,6 @@ class ActionsTest {
   }
 
   @Test
-  fun `should chain underling actions into sequence with action then sequence`() {
-    val firstAction = MockAction()
-    val secondAction = MockAction()
-    val thirdAction = MockAction()
-
-    val sequence = firstAction then Actions.sequence(secondAction, thirdAction)
-
-    assertEquals(firstAction, sequence.actions[0])
-    assertEquals(secondAction, sequence.actions[1])
-    assertEquals(thirdAction, sequence.actions[2])
-    assertEquals(3, sequence.actions.size)
-  }
-
-  @Test
-  fun `should chain underling actions into sequence with sequence then sequence`() {
-    val firstAction = MockAction()
-    val secondAction = MockAction()
-    val thirdAction = MockAction()
-    val fourthAction = MockAction()
-
-    val sequence = Actions.sequence(firstAction, secondAction) then Actions.sequence(thirdAction, fourthAction)
-
-    assertEquals(firstAction, sequence.actions[0])
-    assertEquals(secondAction, sequence.actions[1])
-    assertEquals(thirdAction, sequence.actions[2])
-    assertEquals(fourthAction, sequence.actions[3])
-    assertEquals(4, sequence.actions.size)
-  }
-
-  @Test
   fun `should use existing sequence with then`() {
     val firstAction = SequenceAction(MockAction(), MockAction())
     val secondAction = MockAction()
@@ -159,7 +129,7 @@ class ActionsTest {
   }
 
   @Test
-  fun `should create parallel action given two actors`() {
+  fun `should create parallel action given two actions`() {
     val firstAction = MockAction()
     val secondAction = MockAction()
 
@@ -185,7 +155,7 @@ class ActionsTest {
   }
 
   @Test
-  fun `should create parallel action given a regular action and parallel action`() {
+  fun `should wrap a regular action and parallel action with action along`() {
     val firstAction = MockAction()
     val secondAction = MockAction()
     val thirdAction = MockAction()
@@ -193,25 +163,9 @@ class ActionsTest {
     val parallel = firstAction along Actions.parallel(secondAction, thirdAction)
 
     assertTrue(firstAction in parallel.actions)
-    assertTrue(secondAction in parallel.actions)
-    assertTrue(thirdAction in parallel.actions)
-    assertEquals(3, parallel.actions.size)
-  }
-
-  @Test
-  fun `should create parallel action given two parallel actions`() {
-    val firstAction = MockAction()
-    val secondAction = MockAction()
-    val thirdAction = MockAction()
-    val fourthAction = MockAction()
-
-    val parallel = Actions.parallel(firstAction, secondAction) along Actions.parallel(thirdAction, fourthAction)
-
-    assertTrue(firstAction in parallel.actions)
-    assertTrue(secondAction in parallel.actions)
-    assertTrue(thirdAction in parallel.actions)
-    assertTrue(fourthAction in parallel.actions)
-    assertEquals(4, parallel.actions.size)
+    assertEquals(2, parallel.actions.size)
+    assertSame(secondAction, (parallel.actions[1] as ParallelAction).actions[0])
+    assertSame(thirdAction, (parallel.actions[1] as ParallelAction).actions[1])
   }
 
   @Test

--- a/actors/src/test/kotlin/ktx/actors/actionsTest.kt
+++ b/actors/src/test/kotlin/ktx/actors/actionsTest.kt
@@ -3,7 +3,9 @@ package ktx.actors
 import com.badlogic.gdx.scenes.scene2d.Action
 import com.badlogic.gdx.scenes.scene2d.Actor
 import com.badlogic.gdx.scenes.scene2d.actions.Actions
+import com.badlogic.gdx.scenes.scene2d.actions.ParallelAction
 import com.badlogic.gdx.scenes.scene2d.actions.RepeatAction
+import com.badlogic.gdx.scenes.scene2d.actions.SequenceAction
 import org.junit.Assert.*
 import org.junit.Test
 
@@ -114,20 +116,14 @@ class ActionsTest {
   }
 
   @Test
-  fun `should not mutate multiple actions with then`() {
-    // Given:
-    val firstAction = MockAction()
+  fun `should use existing sequence with then`() {
+    val firstAction = SequenceAction(MockAction(), MockAction())
     val secondAction = MockAction()
-    val thirdAction = MockAction()
+
     val sequence = firstAction then secondAction
 
-    // When:
-    sequence then thirdAction
-
-    // Then: should not mutate firstSequence.
-    assertEquals(2, sequence.actions.size)
-    assertEquals(firstAction, sequence.actions[0])
-    assertEquals(secondAction, sequence.actions[1])
+    assertEquals(3, sequence.actions.size)
+    assertSame(firstAction, sequence)
   }
 
   @Test
@@ -167,7 +163,7 @@ class ActionsTest {
     val firstAction = MockAction()
     val secondAction = MockAction()
 
-    val parallel = firstAction.parallelTo(secondAction) // === firstAction parallelTo secondAction
+    val parallel = firstAction along secondAction // === firstAction parallelTo secondAction
 
     assertTrue(firstAction in parallel.actions)
     assertTrue(secondAction in parallel.actions)
@@ -180,7 +176,7 @@ class ActionsTest {
     val secondAction = MockAction()
     val thirdAction = MockAction()
 
-    val parallel = Actions.parallel(firstAction, secondAction) parallelTo thirdAction
+    val parallel = Actions.parallel(firstAction, secondAction) along thirdAction
 
     assertTrue(firstAction in parallel.actions)
     assertTrue(secondAction in parallel.actions)
@@ -194,7 +190,7 @@ class ActionsTest {
     val secondAction = MockAction()
     val thirdAction = MockAction()
 
-    val parallel = firstAction parallelTo Actions.parallel(secondAction, thirdAction)
+    val parallel = firstAction along Actions.parallel(secondAction, thirdAction)
 
     assertTrue(firstAction in parallel.actions)
     assertTrue(secondAction in parallel.actions)
@@ -209,7 +205,7 @@ class ActionsTest {
     val thirdAction = MockAction()
     val fourthAction = MockAction()
 
-    val parallel = Actions.parallel(firstAction, secondAction) parallelTo Actions.parallel(thirdAction, fourthAction)
+    val parallel = Actions.parallel(firstAction, secondAction) along Actions.parallel(thirdAction, fourthAction)
 
     assertTrue(firstAction in parallel.actions)
     assertTrue(secondAction in parallel.actions)
@@ -224,7 +220,7 @@ class ActionsTest {
     val secondAction = MockAction()
     val thirdAction = MockAction()
 
-    val parallel = firstAction parallelTo secondAction parallelTo thirdAction
+    val parallel = firstAction along secondAction along thirdAction
 
     assertTrue(firstAction in parallel.actions)
     assertTrue(secondAction in parallel.actions)
@@ -233,7 +229,7 @@ class ActionsTest {
   }
 
   @Test
-  fun `should not mutate parallel actions`() {
+  fun `should not mutate parallel actions with +`() {
     val firstAction = MockAction()
     val secondAction = MockAction()
     val thirdAction = MockAction()
@@ -245,6 +241,32 @@ class ActionsTest {
     assertTrue(secondAction in parallel.actions)
     assertFalse(thirdAction in parallel.actions)
     assertEquals(2, parallel.actions.size)
+  }
+
+  @Test
+  fun `should not mutate multiple actions with div`() {
+    val firstAction = MockAction()
+    val secondAction = MockAction()
+    val thirdAction = MockAction()
+    val sequence = Actions.sequence(firstAction, secondAction)
+
+    sequence / thirdAction
+
+    assertTrue(firstAction in sequence.actions)
+    assertTrue(secondAction in sequence.actions)
+    assertFalse(thirdAction in sequence.actions)
+    assertEquals(2, sequence.actions.size)
+  }
+
+  @Test
+  fun `should use existing parallel with along`() {
+    val firstAction = ParallelAction(MockAction(), MockAction())
+    val secondAction = MockAction()
+
+    val parallel = firstAction along secondAction
+
+    assertEquals(3, parallel.actions.size)
+    assertSame(firstAction, parallel)
   }
 
   @Test
@@ -260,6 +282,30 @@ class ActionsTest {
     assertTrue(secondAction in parallel.actions)
     assertTrue(thirdAction in parallel.actions)
     assertEquals(3, parallel.actions.size)
+  }
+
+  @Test
+  fun `should not unwrap sequences with along`() {
+    val firstSequence = SequenceAction(MockAction(), MockAction())
+    val secondSequence = SequenceAction(MockAction(), MockAction())
+
+    val parallel = firstSequence along secondSequence
+
+    assertTrue(firstSequence in parallel.actions)
+    assertTrue(secondSequence in parallel.actions)
+    assertEquals(2, parallel.actions.size)
+  }
+
+  @Test
+  fun `should make sequence actions parallel with div`() {
+    val firstSequence = SequenceAction(MockAction(), MockAction())
+    val secondSequence = SequenceAction(MockAction(), MockAction())
+
+    val parallel = firstSequence / secondSequence
+
+    assertTrue(firstSequence in parallel.actions)
+    assertTrue(secondSequence in parallel.actions)
+    assertEquals(2, parallel.actions.size)
   }
 
   @Test


### PR DESCRIPTION
An implementation of what we discussed in issue #206.

(Edited post discussion and review)
- All unwrapping removed because it is bug-prone.
- `then` is now mutating if the first action is a SequenceAction. The second action is simply added to it.
- `+` is still non-mutating.
- `parallelTo` deprecated for new `along`
- `along` is mutating if the first action is a ParallelAction. The second action is simply added to it.
- `/` added to make ParallelActions without mutating.