### PR TITLE
Added more reified skin extension methods with default style name parameter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 #### 1.9.10-SNAPSHOT
 
+- **[FEATURE]** (`ktx-style`) Added more extension methods to Skin, with reified type and name parameter that
+defaults to the "default" style name. `optional`, `add`, `remove`, `has` and `getAll` extension methods were added.
+The overloaded `+=` operator can also be used to add resource with "default" name.
+
 #### 1.9.10-b2
 
 - **[UPDATE]** Updated to Kotlin 1.3.50.

--- a/style/README.md
+++ b/style/README.md
@@ -35,6 +35,20 @@ Note that both of these functions use reified generics, so they need to be able 
 context. For example, `val font = skin["name"]` would not compile, as the compiler would not be able to guess that
 instance of `BitmapFont` class is requested.
 
+More methods were also added to allow type inference:
+```Kotlin
+val res: Resource? = skin.optional("name")
+val found = skin.has<Resource>("name")
+
+skin.add(resource, "name")
+skin += otherResource  // Uses the "default" name
+
+skin.remove<Resource>("name")
+
+val map: ObjectMap<String, Resource>? = skin.getAll()
+```
+All name parameters can also be left blank to use the default style name, `"default"`.
+
 An extension method for every style of every Scene2D widget was added to `Skin`. Each method name matches `lowerCamelCase`
 name of the actor class. For example, the method used to create `ScrollPaneStyle` instances is named `scrollPane`.
 Signature of every extension method is pretty much the same - they consume 3 parameters: style name (defaults to

--- a/style/src/main/kotlin/ktx/style/style.kt
+++ b/style/src/main/kotlin/ktx/style/style.kt
@@ -21,6 +21,7 @@ import com.badlogic.gdx.scenes.scene2d.ui.Touchpad.TouchpadStyle
 import com.badlogic.gdx.scenes.scene2d.ui.Tree.TreeStyle
 import com.badlogic.gdx.scenes.scene2d.ui.Window.WindowStyle
 import com.badlogic.gdx.utils.GdxRuntimeException
+import com.badlogic.gdx.utils.ObjectMap
 import kotlin.annotation.AnnotationTarget.*
 
 /** Should annotate builder methods of Scene2D [Skin]. */
@@ -72,6 +73,14 @@ inline operator fun <reified Resource : Any> Skin.get(name: String = defaultStyl
 inline operator fun <reified Resource : Any, E : Enum<E>>  Skin.get(name: E): Resource = this[name.toString()]
 
 /**
+ * Utility function that makes it easier to access [Skin] assets or return null if they don't exist.
+ * @param name name of the requested resource. Defaults to [defaultStyle].
+ * @return resource of the specified type with the selected name, or `null` if it doesn't exist.
+ */
+inline fun <reified Resource : Any> Skin.optional(name: String = defaultStyle): Resource? =
+    this.optional(name, Resource::class.java)
+
+/**
  * Utility function that makes it easier to add [Skin] assets.
  * @param name name of the passed resource.
  * @param resource will be added to the skin and mapped to the selected name.
@@ -84,8 +93,45 @@ inline operator fun <reified Resource : Any> Skin.set(name: String, resource: Re
  * @param name name of the passed resource.
  * @param resource will be added to the skin and mapped to the selected name.
  */
-inline operator fun <reified Resource : Any , E : Enum<E>> Skin.set(name: E, resource: Resource) =
-        this.set(name.toString(), resource)
+inline operator fun <reified Resource : Any, E : Enum<E>> Skin.set(name: E, resource: Resource) =
+    this.set(name.toString(), resource)
+
+/**
+ * Utility function that makes it easier to add [Skin] assets.
+ * @param name name of the passed resource. Defaults to [defaultStyle].
+ * @param resource will be added to the skin and mapped to the selected name.
+ */
+inline fun <reified Resource : Any> Skin.add(resource: Resource, name: String = defaultStyle) =
+    this.add(name, resource, Resource::class.java)
+
+/**
+ * Utility function that makes it easier to add [Skin] assets under the [defaultStyle] name.
+ * @param resource will be added to the skin and mapped to the selected name.
+ */
+inline operator fun <reified Resource : Any> Skin.plusAssign(resource: Resource) =
+    this.add(resource)
+
+/**
+ * Utility function that makes it easier to remove [Skin] assets.
+ * @param name name of the passed resource. Defaults to [defaultStyle].
+ * @throws NullPointerException if unable to find the resource.
+ */
+inline fun <reified Resource : Any> Skin.remove(name: String = defaultStyle) =
+    this.remove(name, Resource::class.java)
+
+/**
+ * Utility function that makes it easier to check if [Skin] contains assets.
+ * @param name name of the resource to look for. Defaults to [defaultStyle].
+ */
+inline fun <reified Resource : Any> Skin.has(name: String = defaultStyle): Boolean =
+    this.has(name, Resource::class.java)
+
+/**
+ * Utility function that makes it easier to access all [Skin] assets of a certain type.
+ * @return map of the resources for the [Resource] type, or `null` if no resources of that type is in the skin.
+ */
+inline fun <reified Resource : Any> Skin.getAll(): ObjectMap<String, Resource>? =
+    this.getAll(Resource::class.java)
 
 /**
  * Utility function for adding existing styles to the skin. Mostly for internal use.

--- a/style/src/test/kotlin/ktx/style/styleTest.kt
+++ b/style/src/test/kotlin/ktx/style/styleTest.kt
@@ -101,6 +101,33 @@ class StyleTest {
   }
 
   @Test
+  fun `should extract optional resource with default style name`() {
+    val skin = Skin()
+
+    skin.add(defaultStyle, "Test.")
+
+    skin.optional<String>() shouldBe "Test."
+  }
+
+  @Test
+  fun `should extract optional resource`() {
+    val skin = Skin()
+
+    skin.add("mock", "Test.")
+
+    skin.optional<String>("mock") shouldBe "Test."
+  }
+
+  @Test
+  fun `should extract optional resource and return null`() {
+    val skin = Skin()
+
+    skin.add("asset", "Test.")
+
+    skin.optional<Color>("mock") shouldBe null
+  }
+
+  @Test
   fun `should extract resource with default style name`() {
     val skin = Skin()
 
@@ -170,6 +197,82 @@ class StyleTest {
     val style = skin.get<LabelStyle>("mock")
     assertSame(existing, style)
     style.fontColor shouldBe Color.BLACK
+  }
+
+  @Test
+  fun `should add resource with default style name`() {
+    val skin = Skin()
+
+    skin.add("Test.")
+
+    skin.get<String>() shouldBe "Test."
+  }
+
+  @Test
+  fun `should add resource with default style name with plusAssign`() {
+    val skin = Skin()
+
+    skin += "Test."
+
+    skin.get<String>() shouldBe "Test."
+  }
+
+  @Test
+  fun `should remove resource with default style name`() {
+    val skin = Skin()
+
+    skin.add(defaultStyle, "Test.")
+
+    skin.remove<String>()
+
+    skin.has(defaultStyle, String::class.java) shouldBe false
+  }
+
+  @Test
+  fun `should remove resource`() {
+    val skin = Skin()
+
+    skin.add("mock", "Test.")
+
+    skin.remove<String>("mock")
+
+    skin.has("mock", String::class.java) shouldBe false
+  }
+
+  @Test
+  fun `should check if resource is present`() {
+    val skin = Skin()
+
+    skin.add("mock", "Test.")
+
+    skin.has<String>("mock") shouldBe true
+    skin.has<String>("mock-2") shouldBe false
+  }
+
+  @Test
+  fun `should check if resource with default style name is present`() {
+    val skin = Skin()
+
+    skin.add(defaultStyle, "Test.")
+
+    skin.has<String>() shouldBe true
+  }
+
+  @Test
+  fun `should return a map of all resources of a type`() {
+    val skin = Skin()
+
+    skin.add("mock-1", "Test.")
+    skin.add("mock-2", "Test 2.")
+
+    skin.getAll<String>()!!.size shouldBe 2
+  }
+
+  @Test
+  fun `should return null if resource is not in skin`() {
+    val skin = Skin()
+
+    skin.getAll<String>() shouldBe null
   }
 
   @Test


### PR DESCRIPTION
Added more extension methods to Skin with reified parameters and/or default style name as default parameter value. Here's the changes in syntax with resources named "default":

```kotlin
// Optional
val res: Resource? = skin.optional("default", Resource::class.java)
val res: Resource? = skin.optional()

// Add
skin.add("default", resource)
skin.add(resource)
skin += resource

// Remove
skin.remove("default", Resource::class.java)
skin.remove<Resource>()

// Has
val found = skin.has("default", Resource::class.java)
val found = skin.has<Resource>()

// Get all
val map: ObjectMap<String, Resource>? = skin.getAll(Resource::class.java)
val map: ObjectMap<String, Resource>? = skin.getAll()
```

So now Skin can be fully used without having `Resource::class.java` type arguments and `"default"` name arguments. 

I feel like the latter is important since there is often only one resource of a type so it makes sense not to name it. LibGDX forces the use of `"default"` arguments which is ugly and more error-prone.