### PR TITLE
AssetGroup

### DIFF
--- a/assets/README.md
+++ b/assets/README.md
@@ -63,16 +63,28 @@ such as `loadAll()` or `unloadAll()`. The intended use is to subclass `AssetGrou
 list its member assets as properties using `AssetGroup.asset()` or `AssetGroup.delayedAsset()`. It also allows for using 
 a common prefix for the file names of the group in case they are stored in a specific subdirectory. For example:
 ```Kotlin
-class MapScreenAssets(manager: AssetManager) : AssetGroup(manager, "mapScreen/"){
+/** A group of assets that are stored in the mapScreen directory and are used only on the map screen. */
+class MapScreenAssets(manager: AssetManager) : AssetGroup(manager, filePrefix = "mapScreen/"){
     val atlas by asset<TextureAtlas>("atlas.json")
     val music by asset<Music>("mapScreen.ogg")
 }
 
 val mapScreenAssets = MapScreenAssets(manager)
-//...
-manager.finishLoading()
-//...
-mapScreenAssets.dispose()
+
+// Then, when ready to load them:
+// Using asset() to create the assets pre-queues them once the group is instantiated.
+// If you were using delayedAsset() instead, you would call mapScreenAssets.loadAll() when ready to queue them.
+if (mapScreenAssets.update()) {
+    // The member assets are now ready to use.
+} else {
+    // Continue showing loading screen, for example.
+}
+
+// Alternatively, mapScreenAsset.finishLoading() would block until the assets are loaded, possibly finishing earlier 
+// than manager.finishLoading() would.
+
+// When finished with these assets:
+mapScreenAssets.unloadAll()
 ```
 
 Note: if you can use coroutines in your project, [`ktx-assets-async`](../assets-async) module provides a lightweight

--- a/assets/README.md
+++ b/assets/README.md
@@ -58,6 +58,22 @@ loaded in the first place. Typical usage: `assetManager.unloadSafely("test.png")
 exception thrown during reloading. Note that `AssetManager` can throw `GdxRuntimeException` if the asset was not loaded yet.
 - `AssetManager.getLoader` and `setLoader` extension methods with reified types added to ease handling of `AssetLoader`
 instances registered in the `AssetManager`.
+- The `AssetGroup` class is provided for easily grouping together assets so they can be managed as a group through calls 
+such as `loadAll()` or `unloadAll()`. The intended use is to subclass `AssetGroup` and 
+list its member assets as properties using `AssetGroup.asset()` or `AssetGroup.delayedAsset()`. It also allows for using 
+a common prefix for the file names of the group in case they are stored in a specific subdirectory. For example:
+```Kotlin
+class MapScreenAssets(manager: AssetManager) : AssetGroup(manager, "mapScreen/"){
+    val atlas by asset<TextureAtlas>("atlas.json")
+    val music by asset<Music>("mapScreen.ogg")
+}
+
+val mapScreenAssets = MapScreenAssets(manager)
+//...
+manager.finishLoading()
+//...
+mapScreenAssets.dispose()
+```
 
 Note: if you can use coroutines in your project, [`ktx-assets-async`](../assets-async) module provides a lightweight
 coroutines-based alternative to `AssetManager` that can greatly simplify your asset loading code.

--- a/assets/README.md
+++ b/assets/README.md
@@ -63,27 +63,38 @@ such as `loadAll()` or `unloadAll()`. The intended use is to subclass `AssetGrou
 list its member assets as properties using `AssetGroup.asset()` or `AssetGroup.delayedAsset()`. It also allows for using 
 a common prefix for the file names of the group in case they are stored in a specific subdirectory. For example:
 ```Kotlin
-/** A group of assets that are stored in the mapScreen directory and are used only on the map screen. */
+/** An AssetGroup intended for instantiating at the time it should start being loaded, or an AssetGroup that does not 
+  * share its AssetManager with anything else. The assets are specified by using asset() so they are immediately
+  * queued with the AssetManager when the class is instantiated. */
+class UIAssets(manager: AssetManager) : AssetGroup(manager, filePrefix = "ui/"){
+    val skin by asset<Skin>("skin.json")
+    val clickSound by asset<Sound>("mapScreen.wav")
+}
+
+val uiAssets = UIAssets(manager)
+// No need to queue them. They are pre-queued by instantiating the class.
+uiAssets.finishLoading() // Block until they are finished loading. Incremental loading with update() is also available.
+
+/** An AssetGroup intended for instantiating before its members are needed (possibly referenced among other AssetGroups
+  * as non-nullable properties). The assets are specified using delayedAsset() so they are not queued for loading until
+  * loadAll() is called on the group. */
 class MapScreenAssets(manager: AssetManager) : AssetGroup(manager, filePrefix = "mapScreen/"){
-    val atlas by asset<TextureAtlas>("atlas.json")
+    val atlas by asset<TextureAtlas>("map.atlas")
     val music by asset<Music>("mapScreen.ogg")
 }
 
 val mapScreenAssets = MapScreenAssets(manager)
 
 // Then, when ready to load them:
-// Using asset() to create the assets pre-queues them once the group is instantiated.
-// If you were using delayedAsset() instead, you would call mapScreenAssets.loadAll() when ready to queue them.
+mapScreenAssets.loadALL()
 if (mapScreenAssets.update()) {
     // The member assets are now ready to use.
 } else {
     // Continue showing loading screen, for example.
 }
 
-// Alternatively, mapScreenAsset.finishLoading() would block until the assets are loaded, possibly finishing earlier 
-// than manager.finishLoading() would.
-
 // When finished with these assets:
+uiAssets.unloadAll()
 mapScreenAssets.unloadAll()
 ```
 

--- a/assets/src/main/kotlin/ktx/assets/assets.kt
+++ b/assets/src/main/kotlin/ktx/assets/assets.kt
@@ -257,8 +257,8 @@ abstract class AssetGroup(val manager: AssetManager, protected val filePrefix: S
    * and the associated [AssetManager] will retain them.
    * @param onError Called in response to each caught exception. By default, the exceptions are ignored.
    * */
-  inline fun unloadAllSafely(onError: (Asset<*>, Exception) -> Unit = { _, exception -> exception.ignore() }) {
-    for (member in `access$members`){
+  fun unloadAllSafely(onError: (Asset<*>, Exception) -> Unit = { _, exception -> exception.ignore() }) {
+    for (member in members) {
       try {
         member.unload()
       } catch (exception: Exception) {
@@ -307,7 +307,4 @@ abstract class AssetGroup(val manager: AssetManager, protected val filePrefix: S
   protected inline fun <reified T : Any> delayedAsset(fileName: String, params: AssetLoaderParameters<T>? = null) =
       manager.loadOnDemand("$filePrefix$fileName", params).also { members.add(it) }
 
-  @PublishedApi
-  internal val `access$members`: ObjectSet<Asset<*>>
-    get() = members
 }

--- a/assets/src/main/kotlin/ktx/assets/assets.kt
+++ b/assets/src/main/kotlin/ktx/assets/assets.kt
@@ -6,6 +6,7 @@ import com.badlogic.gdx.assets.AssetManager
 import com.badlogic.gdx.assets.loaders.AssetLoader
 import com.badlogic.gdx.files.FileHandle
 import com.badlogic.gdx.utils.GdxRuntimeException
+import com.badlogic.gdx.utils.ObjectSet
 import kotlin.reflect.KProperty
 
 /**
@@ -70,6 +71,7 @@ class ManagedAsset<Type>(val manager: AssetManager, val assetDescriptor: AssetDe
   override fun finishLoading() {
     if (!isLoaded()) manager.finishLoadingAsset<Type>(assetDescriptor.fileName)
   }
+  override fun toString(): String = "ManagedAsset<${assetDescriptor.type.simpleName}>(${assetDescriptor.fileName})"
 }
 
 /**
@@ -95,6 +97,7 @@ class DelayedAsset<Type>(val manager: AssetManager, val assetDescriptor: AssetDe
       manager.finishLoadingAsset<Type>(assetDescriptor.fileName)
     }
   }
+  override fun toString(): String = "DelayedAsset<${assetDescriptor.type.simpleName}>(${assetDescriptor.fileName})"
 }
 
 /**
@@ -211,4 +214,100 @@ inline fun <reified Type : Any, Parameters : AssetLoaderParameters<Type>> AssetM
     assetLoader: AssetLoader<Type, Parameters>,
     suffix: String? = null) {
   setLoader(Type::class.java, suffix, assetLoader)
+}
+
+/**
+ * A class for managing a group of assets together, such that they can be loaded or unloaded en masse.
+ * [AssetGroup] should be subclassed and the assets should be defined by properties in the subclass by using [asset] or,
+ * [delayedAsset], which can be used as delegates. If not using delegates, it is possible to selectively load and
+ * unload them, in which case it is not advised to use [loadAll] and [unloadAll], because AssetManager's reference
+ * counts may be thrown off.
+ *
+ * If fine control over individual assets of this group is not needed, a strategy to avoid the complexity of
+ * AssetManager's reference counting is to:
+ * - Use [asset]/[delayedAsset] exclusively as delegates.
+ * - Do not mix and match use of [asset] and [delayedAsset].
+ * - Never access any of the asset properties until the group is finished loading.
+ * - Do not initially call [loadAll] if using [asset] (as opposed to [delayedAsset]).
+ * @param manager The [AssetManager] that will handle loading and unloading of this group.
+ * @param filePrefix A string that will be prefixed to any file path parameter passed to [asset] or [delayedAsset].
+ */
+abstract class AssetGroup(val manager: AssetManager, protected val filePrefix: String = "") {
+  /** The backing set containing the assets of this group. There is no need to manually add assets to this set if using
+   * [asset] or [delayedAsset]. */
+  protected val members = ObjectSet<Asset<*>>()
+
+  /** Queues all assets of this group for loading by the associated [AssetManager].
+   * If any assets of this group are already loaded, their load counts in the AssetManager will still be incremented. */
+  fun loadAll() {
+    for (member in members)
+      member.load()
+  }
+
+  /** Unloads all of the assets in this group. If any of the assets are dependencies of assets outside this group, or if
+   * they were loaded more than once, their load counts will only be decremented by one and the associated [AssetManager]
+   * will retain them. */
+  fun unloadAll() {
+    for (member in members)
+      member.unload()
+  }
+
+  /** Unloads all of the assets in this group, catching any exceptions. If any of the assets are dependencies of
+   * assets outside this group, or if they were loaded more than once, their load counts will only be decremented by one
+   * and the associated [AssetManager] will retain them.
+   * @param onError Called in response to each caught exception. By default, the exceptions are ignored.
+   * */
+  inline fun unloadAllSafely(onError: (Asset<*>, Exception) -> Unit = { _, exception -> exception.ignore() }) {
+    for (member in `access$members`){
+      try {
+        member.unload()
+      } catch (exception: Exception) {
+        onError(member, exception)
+      }
+    }
+  }
+
+  /** Updates the associated [AssetManager] if the members of this group are not finished loading. This does not
+   * prioritize this group's assets, but it might provide early feedback that the members of this specific group are
+   * ready.
+   * @return Whether the assets of this group are finished loading.
+   */
+  fun update() = isLoaded() || manager.update()
+
+  /** Blocks until all members of this group are loaded. This does not prioritize this group's members, so assets from
+   * outside this group may be loaded as well. */
+  fun finishLoading() {
+    while (!isLoaded()) {
+      if (manager.update()) break
+    }
+  }
+
+  /** @return true if all of the assets in this group are finished being loaded by the associated [AssetManager]. */
+  fun isLoaded() = members.all { it.isLoaded() }
+
+  /** Creates a delegate for an asset, queues it for loading, and registers it as a member of this group. Beware that
+   * calling [loadAll] might increment the [AssetManager]'s reference count for this asset an additional time.
+   * @param fileName Name of the file used to reference this asset by the AssetManager. This value will be prefixed with
+   * [filePrefix].
+   * @param params optional asset loading parameters which might affect how the assets are loaded. Can be null.
+   * @return an [Asset], registered as a member of this AssetGroup.
+   * */
+  protected inline fun <reified T : Any> asset(fileName: String, params: AssetLoaderParameters<T>? = null) =
+      manager.load("$filePrefix$fileName", params).also { members.add(it) }
+
+  /** Creates a delegate for an asset and registers it as a member of this group. It is not queued for loading. Beware
+   * that if the asset property (or delegated property) of the returned [Asset] is accessed before it is queued for
+   * loading, it will eagerly be loaded by the [AssetManager]. This may cause [loadAll] to throw off AssetManager's
+   * reference counts.
+   * @param fileName Name of the file used to reference this asset by the AssetManager. This value will be prefixed with
+   * [filePrefix].
+   * @param params optional asset loading parameters which might affect how the assets are loaded. Can be null.
+   * @return an [Asset], registered as a member of this AssetGroup.
+   * */
+  protected inline fun <reified T : Any> delayedAsset(fileName: String, params: AssetLoaderParameters<T>? = null) =
+      manager.loadOnDemand("$filePrefix$fileName", params).also { members.add(it) }
+
+  @PublishedApi
+  internal val `access$members`: ObjectSet<Asset<*>>
+    get() = members
 }

--- a/assets/src/test/kotlin/ktx/assets/assetsTest.kt
+++ b/assets/src/test/kotlin/ktx/assets/assetsTest.kt
@@ -169,6 +169,15 @@ class AssetsTest {
   }
 
   @Test
+  fun `should ignore exception due to prior disposal`() {
+    assetManager.load<MockAsset>("test")
+    assetManager.finishLoading()
+    val mockAsset = assetManager.get<MockAsset>("test")
+    mockAsset.dispose()
+    assetManager.unloadSafely("test")
+  }
+
+  @Test
   fun `should unload asset handling exception`() {
     assetManager.load<MockAsset>("test")
     assetManager.finishLoading()
@@ -431,6 +440,78 @@ class AssetsTest {
 
     assertSame(loader, manager.getLoader(MockAsset::class.java, ".mock"))
   }
+
+  @Test
+  fun `should load and unload members`() {
+    class TestAssetGroup : AssetGroup(assetManager){
+      val member1 by asset<MockAsset>("member1")
+      val member2 by asset<MockAsset>("member2")
+    }
+
+    val group = TestAssetGroup()
+    group.finishLoading()
+    assert(group.isLoaded())
+
+    val mockAssets = listOf(group.member1, group.member2)
+    group.unloadAll()
+    assert(!group.isLoaded())
+    for (mockAsset in mockAssets)
+      assert(mockAsset.disposed)
+  }
+
+  @Test
+  fun `should load by update`() {
+    class TestAssetGroup : AssetGroup(assetManager){
+      val member1 by asset<MockAsset>("member1")
+      val member2 by asset<MockAsset>("member2")
+      val member3 by asset<MockAsset>("member3")
+    }
+    val nonmember = assetManager.load<MockAsset>("nonmember")
+
+    val group = TestAssetGroup()
+    nonmember.load()
+    while (true){
+      if (group.update())
+        break
+    }
+    assert(group.isLoaded())
+  }
+
+  @Test
+  fun `should catch exceptions`() {
+    class TestAssetGroup : AssetGroup(assetManager){
+      val member1 by asset<MockAsset>("member1")
+      val member2 by asset<MockAsset>("member2")
+    }
+
+    val group = TestAssetGroup()
+    with(group) {
+      finishLoading()
+      member1.dispose()
+      member2.dispose()
+    }
+
+    var caught = 0
+    group.unloadAllSafely { _, _ ->
+      caught++
+    }
+    assertEquals(caught, 2)
+  }
+
+  @Test
+  fun `should apply prefix`() {
+    class TestAssetGroup : AssetGroup(assetManager, "prefix/") {
+      val member1 = delayedAsset<MockAsset>("member1")
+      val member2 = delayedAsset<MockAsset>("member2")
+    }
+
+    val group = TestAssetGroup().apply {
+      loadAll()
+      manager.finishLoading()
+    }
+    for (i in 1..2)
+      assert(group.manager.isLoaded("prefix/member$i"))
+  }
 }
 
 /**
@@ -448,6 +529,7 @@ private fun managerWithMockAssetLoader() = AssetManager().apply {
 class MockAsset(val data: String, val additional: String?) : Disposable {
   var disposed = false
   override fun dispose() {
+    require(!disposed) { "Was already disposed!" } // Simulate behavior of some Gdx assets
     disposed = true
   }
 }
@@ -477,4 +559,5 @@ class MockAssetLoader(fileHandleResolver: FileHandleResolver) :
 
   /** Allows to set [MockAsset.additional] via loader. Tests assets parameters API. */
   class MockParameter(val additional: String?) : AssetLoaderParameters<MockAsset>()
+
 }


### PR DESCRIPTION
This is for #222 .

A few notes:

- `members` is protected so it can be accessed by the protected `asset()` and `delayedAsset()` inline functions. There's also an internal `@PublishedApi` for it so it can be used for the `unloadAllSafely()` inline function. But I thought in some cases someone might want to customize the `asset()`/`delayedAsset()` functions and therefore need a way to directly add to the set.
- I added `toString()` for the two types of assets so reacting to caught exceptions in `unloadAllSafely()`  gives you something that is useful to log. Otherwise, you have very little clue as to which asset threw the exception.
- I made MockAsset throw an exception if disposed twice, which is something some Gdx classes do, so I thought it would help effectively test safe unloading.
