### PR TITLE
Optional pool freeing when using removeAll or retainAll

### DIFF
--- a/collections/README.md
+++ b/collections/README.md
@@ -32,7 +32,8 @@ chained.
 - Missing `addAll` and `removeAll` methods for arrays and iterables were added.
 - `iterate` method allows to iterate over collection's elements, while providing reference to `MutableInterator`. Can be
 used to easily remove collection elements during iteration.
-- `removeAll` and `retainAll` higher-order functions that work like functions in Kotlin stdlib
+- `removeAll` and `retainAll` higher-order functions that work like functions in Kotlin stdlib. A Pool can optionally be 
+passed to automatically free the removed items.
 - `map`, `filter`, `flatten` and `flatMap` methods that work like methods in Kotlin stdlib but return `GdxArray`.
 - Every iterable and array can be converted to `Array` using `toGdxArray` method.
 - `IntArray`, `BooleanArray` and `FloatArray` can be converted to corresponding LibGDX primitive collections using

--- a/collections/src/main/kotlin/ktx/collections/arrays.kt
+++ b/collections/src/main/kotlin/ktx/collections/arrays.kt
@@ -6,16 +6,22 @@ import com.badlogic.gdx.utils.Pool
 
 /** Alias for [com.badlogic.gdx.utils.Array] avoiding name collision with the standard library. */
 typealias GdxArray<Element> = com.badlogic.gdx.utils.Array<Element>
+
 /** Alias for [com.badlogic.gdx.utils.BooleanArray] avoiding name collision with the standard library. */
 typealias GdxBooleanArray = com.badlogic.gdx.utils.BooleanArray
+
 /** Alias for [com.badlogic.gdx.utils.FloatArray] avoiding name collision with the standard library. */
 typealias GdxFloatArray = com.badlogic.gdx.utils.FloatArray
+
 /** Alias for [com.badlogic.gdx.utils.IntArray] avoiding name collision with the standard library. */
 typealias GdxIntArray = com.badlogic.gdx.utils.IntArray
+
 /** Alias for [com.badlogic.gdx.utils.CharArray] avoiding name collision with the standard library. */
 typealias GdxCharArray = com.badlogic.gdx.utils.CharArray
+
 /** Alias for [com.badlogic.gdx.utils.LongArray] avoiding name collision with the standard library. */
 typealias GdxLongArray = com.badlogic.gdx.utils.LongArray
+
 /** Alias for [com.badlogic.gdx.utils.ShortArray] avoiding name collision with the standard library. */
 typealias GdxShortArray = com.badlogic.gdx.utils.ShortArray
 

--- a/collections/src/main/kotlin/ktx/collections/arrays.kt
+++ b/collections/src/main/kotlin/ktx/collections/arrays.kt
@@ -2,6 +2,8 @@
 
 package ktx.collections
 
+import com.badlogic.gdx.utils.Pool
+
 /** Alias for [com.badlogic.gdx.utils.Array] avoiding name collision with the standard library. */
 typealias GdxArray<Element> = com.badlogic.gdx.utils.Array<Element>
 /** Alias for [com.badlogic.gdx.utils.BooleanArray] avoiding name collision with the standard library. */
@@ -227,8 +229,9 @@ inline fun <Type, R : Comparable<R>> GdxArray<out Type>.sortByDescending(crossin
 
 /**
  * Removes elements from the array that satisfy the predicate.
+ * @param pool Removed items are freed to this pool.
  */
-inline fun <Type> GdxArray<Type>.removeAll(predicate: (Type) -> Boolean) {
+inline fun <Type> GdxArray<Type>.removeAll(pool: Pool<Type>?, predicate: (Type) -> Boolean) {
   var currentWriteIndex = 0
   for (i in 0 until size) {
     val value = items[i]
@@ -237,6 +240,8 @@ inline fun <Type> GdxArray<Type>.removeAll(predicate: (Type) -> Boolean) {
         items[currentWriteIndex] = value
       }
       currentWriteIndex++
+    } else {
+      pool?.free(value)
     }
   }
   truncate(currentWriteIndex)
@@ -244,8 +249,9 @@ inline fun <Type> GdxArray<Type>.removeAll(predicate: (Type) -> Boolean) {
 
 /**
  * Removes elements from the array that do not satisfy the predicate.
+ * @param pool Removed items are freed to this optional pool.
  */
-inline fun <Type> GdxArray<Type>.retainAll(predicate: (Type) -> Boolean) {
+inline fun <Type> GdxArray<Type>.retainAll(pool: Pool<Type>? = null, predicate: (Type) -> Boolean) {
   var currentWriteIndex = 0
   for (i in 0 until size) {
     val value = items[i]
@@ -254,6 +260,8 @@ inline fun <Type> GdxArray<Type>.retainAll(predicate: (Type) -> Boolean) {
         items[currentWriteIndex] = value
       }
       currentWriteIndex++
+    } else {
+      pool?.free(value)
     }
   }
   truncate(currentWriteIndex)

--- a/collections/src/test/kotlin/ktx/collections/arraysTest.kt
+++ b/collections/src/test/kotlin/ktx/collections/arraysTest.kt
@@ -1,5 +1,8 @@
 package ktx.collections
 
+import com.badlogic.gdx.math.Vector2
+import com.badlogic.gdx.utils.Pool
+import com.badlogic.gdx.utils.Pools
 import org.junit.Assert.*
 import org.junit.Test
 import java.util.LinkedList
@@ -381,6 +384,16 @@ class ArraysTest {
   }
 
   @Test
+  fun `should free removed elements`() {
+    val array = GdxArray.with(Vector2(), Vector2(1f, 1f), Vector2(2f, 2f))
+    val pool = object : Pool<Vector2>() {
+      override fun newObject() = Vector2()
+    }
+    array.removeAll(pool) { it.len() > 0.5f }
+    assertEquals(pool.peak, 2)
+  }
+
+  @Test
   fun `should retain elements from existing GdxArray`() {
     val array = GdxArray.with(1, 2, 3, 4, 5)
     array.retainAll { it < 6 }
@@ -394,6 +407,16 @@ class ArraysTest {
 
     array.retainAll { it > 0 }
     assertEquals(GdxArray<Int>(), array)
+  }
+
+  @Test
+  fun `should free unretained elements`() {
+    val array = GdxArray.with(Vector2(), Vector2(1f, 1f), Vector2(2f, 2f))
+    val pool = object : Pool<Vector2>() {
+      override fun newObject() = Vector2()
+    }
+    array.retainAll(pool) { it.len() < 0.5f }
+    assertEquals(pool.peak, 2)
   }
 
   @Test


### PR DESCRIPTION
These two functions could not be used if you want to free the removed items to a pool. The alternative would be to return the removed items, but that would create allocation/GC churn for something that is not always needed. And by far the most likely thing you would ever do with a removed item, if anything,  is return it to a pool.

I elected not to add this to `filter` as you would likely not use `filter` with pooled items. Pooled items are used in situations where the array is probably large and allocation/GC churn is trying to be avoided, so you would likely also want to be doing an in-place filter with `retainAll`.