### PR TITLE
removeAll/retainAll return Boolean; transfer less strict

### DIFF
--- a/collections/src/main/kotlin/ktx/collections/arrays.kt
+++ b/collections/src/main/kotlin/ktx/collections/arrays.kt
@@ -237,7 +237,7 @@ inline fun <Type, R : Comparable<R>> GdxArray<out Type>.sortByDescending(crossin
  * Removes elements from the array that satisfy the [predicate].
  * @param pool Removed items are freed to this pool.
  */
-inline fun <Type> GdxArray<Type>.removeAll(pool: Pool<Type>? = null, predicate: (Type) -> Boolean) {
+inline fun <Type> GdxArray<Type>.removeAll(pool: Pool<Type>? = null, predicate: (Type) -> Boolean): Boolean {
   var currentWriteIndex = 0
   for (i in 0 until size) {
     val value = items[i]
@@ -250,14 +250,18 @@ inline fun <Type> GdxArray<Type>.removeAll(pool: Pool<Type>? = null, predicate: 
       pool?.free(value)
     }
   }
-  truncate(currentWriteIndex)
+  if (currentWriteIndex < size) {
+    truncate(currentWriteIndex)
+    return true
+  }
+  return false
 }
 
 /**
  * Removes elements from the array that do not satisfy the [predicate].
  * @param pool Removed items are freed to this optional pool.
  */
-inline fun <Type> GdxArray<Type>.retainAll(pool: Pool<Type>? = null, predicate: (Type) -> Boolean) {
+inline fun <Type> GdxArray<Type>.retainAll(pool: Pool<Type>? = null, predicate: (Type) -> Boolean): Boolean {
   var currentWriteIndex = 0
   for (i in 0 until size) {
     val value = items[i]
@@ -270,14 +274,18 @@ inline fun <Type> GdxArray<Type>.retainAll(pool: Pool<Type>? = null, predicate: 
       pool?.free(value)
     }
   }
-  truncate(currentWriteIndex)
+  if (currentWriteIndex < size) {
+    truncate(currentWriteIndex)
+    return true
+  }
+  return false
 }
 
 /**
  * Transfers elements that match the [predicate] into the selected [toArray].
  * The elements will be removed from this array and added [toArray].
  */
-inline fun <Type> GdxArray<Type>.transfer(toArray: GdxArray<Type>, predicate: (Type) -> Boolean) {
+inline fun <Type: T, T> GdxArray<Type>.transfer(toArray: GdxArray<T>, predicate: (Type) -> Boolean) {
   var currentWriteIndex = 0
   for (i in 0 until size) {
     val value = items[i]

--- a/collections/src/test/kotlin/ktx/collections/arraysTest.kt
+++ b/collections/src/test/kotlin/ktx/collections/arraysTest.kt
@@ -2,7 +2,6 @@ package ktx.collections
 
 import com.badlogic.gdx.math.Vector2
 import com.badlogic.gdx.utils.Pool
-import com.badlogic.gdx.utils.Pools
 import org.junit.Assert.*
 import org.junit.Test
 import java.util.LinkedList
@@ -370,16 +369,20 @@ class ArraysTest {
   @Test
   fun `should remove elements from existing GdxArray`() {
     val array = GdxArray.with(1, 2, 3, 4, 5)
-    array.removeAll { it > 10 }
+    val noneRemovedResult = array.removeAll { it > 10 }
+    assert(!noneRemovedResult)
     assertEquals(GdxArray.with(1, 2, 3, 4, 5), array)
 
-    array.removeAll { it % 2 == 0 }
+    val evensRemovedResult = array.removeAll { it % 2 == 0 }
+    assert(evensRemovedResult)
     assertEquals(GdxArray.with(1, 3, 5), array)
 
-    array.removeAll { it is Number }
+    val allRemovedResult = array.removeAll { it is Number }
+    assert(allRemovedResult)
     assertEquals(GdxArray<Int>(), array)
 
-    array.removeAll { it > 0 }
+    val emptyRemoveResult = array.removeAll { it > 0 }
+    assert(!emptyRemoveResult)
     assertEquals(GdxArray<Int>(), array)
   }
 
@@ -446,18 +449,35 @@ class ArraysTest {
   }
 
   @Test
+  fun `should transfer to wider typed array`(){
+    val array = GdxArray.with("ABC", "AB", "ABC")
+    val target = GdxArray<CharSequence>()
+
+    array.transfer(target) {
+      it.length < 3
+    }
+
+    assertEquals(GdxArray.with("ABC", "ABC"), array)
+    assertEquals(GdxArray.with("AB" as CharSequence), target)
+  }
+
+  @Test
   fun `should retain elements from existing GdxArray`() {
     val array = GdxArray.with(1, 2, 3, 4, 5)
-    array.retainAll { it < 6 }
+    val allRetainedResult = array.retainAll { it < 6 }
+    assert(!allRetainedResult)
     assertEquals(GdxArray.with(1, 2, 3, 4, 5), array)
 
-    array.retainAll { it % 2 == 1 }
+    val oddsRetainedResult = array.retainAll { it % 2 == 1 }
+    assert(oddsRetainedResult)
     assertEquals(GdxArray.with(1, 3, 5), array)
 
-    array.retainAll { it < 0 }
+    val noneRetainedResult = array.retainAll { it < 0 }
+    assert(noneRetainedResult)
     assertEquals(GdxArray<Int>(), array)
 
-    array.retainAll { it > 0 }
+    val emptyRetainResult = array.retainAll { it > 0 }
+    assert(!emptyRetainResult)
     assertEquals(GdxArray<Int>(), array)
   }
 


### PR DESCRIPTION
A couple of changes I hadn't pushed yet when #232 was merged.

`removeAll` and `retainAll` should return Boolean like the stlib functions do.

And I thought `transfer` could be less strict about the target array type.