### PR TITLE
(#238) adds touch event extensions for actors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
     - `containsProperty`
   - Added `shape` extension field to `MapObject`.
   - Added extension fields that ease extraction of basic properties from `TiledMap` and `MapObject`.
+ - **[FEATURE]** (`ktx-actors`) Added extensions for `touch` events like `touchDown` and `touchUp` to be able to react on actor presses and releases
 
 #### 1.9.10-b3
 

--- a/actors/README.md
+++ b/actors/README.md
@@ -144,21 +144,27 @@ button.onTouchUp {
 
 button.onTouchEvent(
   // If you need access to the original InputEvent, use this expanded method variant.
-  downListener = { inputEvent, actor -> println("$actor down by $inputEvent!"); true },
+  downListener = { inputEvent, actor -> println("$actor down by $inputEvent!") },
   upListener = { inputEvent, actor -> println("$actor up by $inputEvent!") }
 )
+// or with a single lambda. In this case you can use InputEvent.Type to distinguish between touchDown and touchUp
+button.onTouchEvent( { inputEvent, actor -> println("$actor ${inputEvent.type} by $inputEvent!") })
 
 button.onTouchEvent(
   // If you need access to the local actor coordinates, use this expanded method variant.
-  downListener = { inputEvent, actor, x, y -> println("$actor down by $inputEvent! at ($x, $y)"); true },
-  upListener = { inputEvent, actor, x, y -> println("$actor up by $inputEvent! at ($x, $y)")}
+  downListener = { inputEvent, actor, x, y -> println("$actor down by $inputEvent at ($x, $y)!") },
+  upListener = { inputEvent, actor, x, y -> println("$actor up by $inputEvent at ($x, $y)!")}
 )
+// or again as single lambda
+button.onTouchEvent( { inputEvent, actor -> println("$actor ${inputEvent.type} by $inputEvent at ($x, $y)!") })
 
 button.onTouchEvent(
   // If you need access to the pointer and mouse button, use this expanded method variant.
-  downListener = { inputEvent, actor, x, y, pointer, mouseButton -> println("$actor down by $inputEvent! at ($x, $y) with pointer $pointer and mouseButton $mouseButton"); true },
-  upListener = { inputEvent, actor, x, y, pointer, mouseButton -> println("$actor up by $inputEvent! at ($x, $y) with pointer $pointer and mouseButton $mouseButton")}
+  downListener = { inputEvent, actor, x, y, pointer, mouseButton -> println("$actor down by $inputEvent at ($x, $y) with pointer $pointer and mouseButton $mouseButton!") },
+  upListener = { inputEvent, actor, x, y, pointer, mouseButton -> println("$actor up by $inputEvent at ($x, $y) with pointer $pointer and mouseButton $mouseButton!")}
 )
+// or again as single lambda
+button.onTouchEvent( { inputEvent, actor -> println("$actor ${inputEvent.type} by $inputEvent at ($x, $y) with pointer $pointer and mouseButton $mouseButton!") })
 ```
 
 Adding an `EventListener` which consumes typed characters:

--- a/actors/README.md
+++ b/actors/README.md
@@ -27,6 +27,7 @@ a `Group` with `actor in group` syntax.
 
 - Lambda-compatible `Actor.onChange` method was added. Allows to listen to `ChangeEvents`.
 - Lambda-compatible `Actor.onClick` method was added. Attaches `ClickListeners`.
+- Lambda-compatible `Actor.onTouchDown` and `Actor.onTouchUp` methods were added. Attaches `ClickListeners`. 
 - Lambda-compatible `Actor.onKey` method was added. Allows to listen to `InputEvents` with `keyTyped` type.
 - Lambda-compatible `Actor.onKeyDown` and `Actor.onKeyUp` methods were added. They allow to listen to `InputEvents`
 with `keyDown` and `keyUp` type, consuming key code of the pressed or released key (see LibGDX `Keys` class).
@@ -34,7 +35,7 @@ with `keyDown` and `keyUp` type, consuming key code of the pressed or released k
 - Lambda-compatible `Actor.onKeyboardFocus` method was added. Allows to listen to `FocusEvents` with `keyboard` type.
 - `KtxInputListener` is an open class that extends `InputListener` with no-op default implementations and type
 improvements (nullability data).
-- `onChangeEvent`, `onClickEvent`, `onKeyEvent`, `onKeyDownEvent`, `onKeyUpEvent`, `onScrollFocusEvent` and
+- `onChangeEvent`, `onClickEvent`, `onTouchEvent`, `onKeyEvent`, `onKeyDownEvent`, `onKeyUpEvent`, `onScrollFocusEvent` and
 `onKeyboardFocusEvent` `Actor` extension methods were added. They consume the relevant `Event` instances as lambda
 parameters. Both listener factory variants are inlined, but the ones ending with *Event* provide more lambda parameters
 and allow to inspect the original `Event` instance that triggered the listener. Regular listener factory methods should
@@ -131,6 +132,33 @@ label.onClickEvent { inputEvent, actor, x, y ->
   // If you need access to the local actor click coordinates, use this expanded method variant.
   println("$actor clicked by $inputEvent at ($x, $y)!")
 }
+
+button.onTouchDown {
+  println("Button down!")
+  true
+}
+
+button.onTouchUp {
+  println("Button up!")
+}
+
+button.onTouchEvent(
+  // If you need access to the original InputEvent, use this expanded method variant.
+  downListener = { inputEvent, actor -> println("$actor down by $inputEvent!"); true },
+  upListener = { inputEvent, actor -> println("$actor up by $inputEvent!") }
+)
+
+button.onTouchEvent(
+  // If you need access to the local actor coordinates, use this expanded method variant.
+  downListener = { inputEvent, actor, x, y -> println("$actor down by $inputEvent! at ($x, $y)"); true },
+  upListener = { inputEvent, actor, x, y -> println("$actor up by $inputEvent! at ($x, $y)")}
+)
+
+button.onTouchEvent(
+  // If you need access to the pointer and mouse button, use this expanded method variant.
+  downListener = { inputEvent, actor, x, y, pointer, mouseButton -> println("$actor down by $inputEvent! at ($x, $y) with pointer $pointer and mouseButton $mouseButton"); true },
+  upListener = { inputEvent, actor, x, y, pointer, mouseButton -> println("$actor up by $inputEvent! at ($x, $y) with pointer $pointer and mouseButton $mouseButton")}
+)
 ```
 
 Adding an `EventListener` which consumes typed characters:

--- a/actors/src/main/kotlin/ktx/actors/events.kt
+++ b/actors/src/main/kotlin/ktx/actors/events.kt
@@ -86,7 +86,7 @@ inline fun <Widget : Actor> Widget.onClickEvent(
  * @return [ClickListener] instance.
  */
 inline fun Actor.onTouchDown(crossinline listener: () -> Boolean): ClickListener {
-  val clickListener = object: ClickListener() {
+  val clickListener = object : ClickListener() {
     override fun touchDown(event: InputEvent, x: Float, y: Float, pointer: Int, button: Int) = listener()
   }
   this.addListener(clickListener)
@@ -99,7 +99,7 @@ inline fun Actor.onTouchDown(crossinline listener: () -> Boolean): ClickListener
  * @return [ClickListener] instance.
  */
 inline fun Actor.onTouchUp(crossinline listener: () -> Unit): ClickListener {
-  val clickListener = object: ClickListener() {
+  val clickListener = object : ClickListener() {
     override fun touchUp(event: InputEvent, x: Float, y: Float, pointer: Int, button: Int) = listener()
   }
   this.addListener(clickListener)
@@ -110,16 +110,20 @@ inline fun Actor.onTouchUp(crossinline listener: () -> Unit): ClickListener {
  * Attaches a [ClickListener] to this actor.
  * @param downListener invoked each time this actor is touched. Consumes the triggered [InputEvent] and the [Actor] that
  * the listener was originally attached to. Refer to [ClickListener.touchDown] for parameter details.
- * * @param upListener invoked each time the touch of the actor is released. Consumes the triggered [InputEvent] and the [Actor] that
+ * @param upListener invoked each time the touch of the actor is released. Consumes the triggered [InputEvent] and the [Actor] that
  * the listener was originally attached to. Refer to [ClickListener.touchUp] for parameter details.
  * @return [ClickListener] instance.
  */
 inline fun <Widget : Actor> Widget.onTouchEvent(
   crossinline downListener: (event: InputEvent, actor: Widget) -> Boolean,
-  crossinline upListener: (event: InputEvent, actor: Widget) -> Unit): ClickListener {
+  crossinline upListener: (event: InputEvent, actor: Widget) -> Unit
+): ClickListener {
   val clickListener = object : ClickListener() {
-    override fun touchDown(event: InputEvent, x: Float, y: Float, pointer: Int, button: Int): Boolean = downListener(event, this@onTouchEvent)
-    override fun touchUp(event: InputEvent, x: Float, y: Float, pointer: Int, button: Int) = upListener(event, this@onTouchEvent)
+    override fun touchDown(event: InputEvent, x: Float, y: Float, pointer: Int, button: Int): Boolean =
+      downListener(event, this@onTouchEvent)
+
+    override fun touchUp(event: InputEvent, x: Float, y: Float, pointer: Int, button: Int) =
+      upListener(event, this@onTouchEvent)
   }
   this.addListener(clickListener)
   return clickListener
@@ -129,16 +133,20 @@ inline fun <Widget : Actor> Widget.onTouchEvent(
  * Attaches a [ClickListener] to this actor.
  * @param downListener invoked each time this actor is touched. Consumes the triggered [InputEvent] and the [Actor] that
  * the listener was originally attached to. Refer to [ClickListener.touchDown] for parameter details.
- * * @param upListener invoked each time the touch of the actor is released. Consumes the triggered [InputEvent] and the [Actor] that
+ * @param upListener invoked each time the touch of the actor is released. Consumes the triggered [InputEvent] and the [Actor] that
  * the listener was originally attached to. Refer to [ClickListener.touchUp] for parameter details.
  * @return [ClickListener] instance.
  */
 inline fun <Widget : Actor> Widget.onTouchEvent(
   crossinline downListener: (event: InputEvent, actor: Widget, x: Float, y: Float) -> Boolean,
-  crossinline upListener: (event: InputEvent, actor: Widget, x: Float, y: Float) -> Unit): ClickListener {
+  crossinline upListener: (event: InputEvent, actor: Widget, x: Float, y: Float) -> Unit
+): ClickListener {
   val clickListener = object : ClickListener() {
-    override fun touchDown(event: InputEvent, x: Float, y: Float, pointer: Int, button: Int): Boolean = downListener(event, this@onTouchEvent, x, y)
-    override fun touchUp(event: InputEvent, x: Float, y: Float, pointer: Int, button: Int) = upListener(event, this@onTouchEvent, x, y)
+    override fun touchDown(event: InputEvent, x: Float, y: Float, pointer: Int, button: Int): Boolean =
+      downListener(event, this@onTouchEvent, x, y)
+
+    override fun touchUp(event: InputEvent, x: Float, y: Float, pointer: Int, button: Int) =
+      upListener(event, this@onTouchEvent, x, y)
   }
   this.addListener(clickListener)
   return clickListener
@@ -148,16 +156,20 @@ inline fun <Widget : Actor> Widget.onTouchEvent(
  * Attaches a [ClickListener] to this actor.
  * @param downListener invoked each time this actor is touched. Consumes the triggered [InputEvent] and the [Actor] that
  * the listener was originally attached to. Refer to [ClickListener.touchDown] for parameter details.
- * * @param upListener invoked each time the touch of the actor is released. Consumes the triggered [InputEvent] and the [Actor] that
+ * @param upListener invoked each time the touch of the actor is released. Consumes the triggered [InputEvent] and the [Actor] that
  * the listener was originally attached to. Refer to [ClickListener.touchUp] for parameter details.
  * @return [ClickListener] instance.
  */
 inline fun <Widget : Actor> Widget.onTouchEvent(
   crossinline downListener: (event: InputEvent, actor: Widget, x: Float, y: Float, pointer: Int, button: Int) -> Boolean,
-  crossinline upListener: (event: InputEvent, actor: Widget, x: Float, y: Float, pointer: Int, button: Int) -> Unit): ClickListener {
+  crossinline upListener: (event: InputEvent, actor: Widget, x: Float, y: Float, pointer: Int, button: Int) -> Unit
+): ClickListener {
   val clickListener = object : ClickListener() {
-    override fun touchDown(event: InputEvent, x: Float, y: Float, pointer: Int, button: Int): Boolean = downListener(event, this@onTouchEvent, x, y, pointer, button)
-    override fun touchUp(event: InputEvent, x: Float, y: Float, pointer: Int, button: Int) = upListener(event, this@onTouchEvent, x, y, pointer, button)
+    override fun touchDown(event: InputEvent, x: Float, y: Float, pointer: Int, button: Int): Boolean =
+      downListener(event, this@onTouchEvent, x, y, pointer, button)
+
+    override fun touchUp(event: InputEvent, x: Float, y: Float, pointer: Int, button: Int) =
+      upListener(event, this@onTouchEvent, x, y, pointer, button)
   }
   this.addListener(clickListener)
   return clickListener

--- a/actors/src/main/kotlin/ktx/actors/events.kt
+++ b/actors/src/main/kotlin/ktx/actors/events.kt
@@ -81,6 +81,89 @@ inline fun <Widget : Actor> Widget.onClickEvent(
 }
 
 /**
+ * Attaches a [ClickListener] to this actor.
+ * @param listener invoked each time this actor is touched.
+ * @return [ClickListener] instance.
+ */
+inline fun Actor.onTouchDown(crossinline listener: () -> Boolean): ClickListener {
+  val clickListener = object: ClickListener() {
+    override fun touchDown(event: InputEvent, x: Float, y: Float, pointer: Int, button: Int) = listener()
+  }
+  this.addListener(clickListener)
+  return clickListener
+}
+
+/**
+ * Attaches a [ClickListener] to this actor.
+ * @param listener invoked each time the touch of the actor is released.
+ * @return [ClickListener] instance.
+ */
+inline fun Actor.onTouchUp(crossinline listener: () -> Unit): ClickListener {
+  val clickListener = object: ClickListener() {
+    override fun touchUp(event: InputEvent, x: Float, y: Float, pointer: Int, button: Int) = listener()
+  }
+  this.addListener(clickListener)
+  return clickListener
+}
+
+/**
+ * Attaches a [ClickListener] to this actor.
+ * @param downListener invoked each time this actor is touched. Consumes the triggered [InputEvent] and the [Actor] that
+ * the listener was originally attached to. Refer to [ClickListener.touchDown] for parameter details.
+ * * @param upListener invoked each time the touch of the actor is released. Consumes the triggered [InputEvent] and the [Actor] that
+ * the listener was originally attached to. Refer to [ClickListener.touchUp] for parameter details.
+ * @return [ClickListener] instance.
+ */
+inline fun <Widget : Actor> Widget.onTouchEvent(
+  crossinline downListener: (event: InputEvent, actor: Widget) -> Boolean,
+  crossinline upListener: (event: InputEvent, actor: Widget) -> Unit): ClickListener {
+  val clickListener = object : ClickListener() {
+    override fun touchDown(event: InputEvent, x: Float, y: Float, pointer: Int, button: Int): Boolean = downListener(event, this@onTouchEvent)
+    override fun touchUp(event: InputEvent, x: Float, y: Float, pointer: Int, button: Int) = upListener(event, this@onTouchEvent)
+  }
+  this.addListener(clickListener)
+  return clickListener
+}
+
+/**
+ * Attaches a [ClickListener] to this actor.
+ * @param downListener invoked each time this actor is touched. Consumes the triggered [InputEvent] and the [Actor] that
+ * the listener was originally attached to. Refer to [ClickListener.touchDown] for parameter details.
+ * * @param upListener invoked each time the touch of the actor is released. Consumes the triggered [InputEvent] and the [Actor] that
+ * the listener was originally attached to. Refer to [ClickListener.touchUp] for parameter details.
+ * @return [ClickListener] instance.
+ */
+inline fun <Widget : Actor> Widget.onTouchEvent(
+  crossinline downListener: (event: InputEvent, actor: Widget, x: Float, y: Float) -> Boolean,
+  crossinline upListener: (event: InputEvent, actor: Widget, x: Float, y: Float) -> Unit): ClickListener {
+  val clickListener = object : ClickListener() {
+    override fun touchDown(event: InputEvent, x: Float, y: Float, pointer: Int, button: Int): Boolean = downListener(event, this@onTouchEvent, x, y)
+    override fun touchUp(event: InputEvent, x: Float, y: Float, pointer: Int, button: Int) = upListener(event, this@onTouchEvent, x, y)
+  }
+  this.addListener(clickListener)
+  return clickListener
+}
+
+/**
+ * Attaches a [ClickListener] to this actor.
+ * @param downListener invoked each time this actor is touched. Consumes the triggered [InputEvent] and the [Actor] that
+ * the listener was originally attached to. Refer to [ClickListener.touchDown] for parameter details.
+ * * @param upListener invoked each time the touch of the actor is released. Consumes the triggered [InputEvent] and the [Actor] that
+ * the listener was originally attached to. Refer to [ClickListener.touchUp] for parameter details.
+ * @return [ClickListener] instance.
+ */
+inline fun <Widget : Actor> Widget.onTouchEvent(
+  crossinline downListener: (event: InputEvent, actor: Widget, x: Float, y: Float, pointer: Int, button: Int) -> Boolean,
+  crossinline upListener: (event: InputEvent, actor: Widget, x: Float, y: Float, pointer: Int, button: Int) -> Unit): ClickListener {
+  val clickListener = object : ClickListener() {
+    override fun touchDown(event: InputEvent, x: Float, y: Float, pointer: Int, button: Int): Boolean = downListener(event, this@onTouchEvent, x, y, pointer, button)
+    override fun touchUp(event: InputEvent, x: Float, y: Float, pointer: Int, button: Int) = upListener(event, this@onTouchEvent, x, y, pointer, button)
+  }
+  this.addListener(clickListener)
+  return clickListener
+}
+
+/**
  * Attaches an [EventListener] optimized to listen for key type events fired for this actor.
  * @param catchEvent if true, the event will not be passed further after it is handled by this listener. Defaults to false.
  * @param listener invoked each time this actor is keyboard-focused and a key is typed. Consumes the typed character.

--- a/actors/src/main/kotlin/ktx/actors/events.kt
+++ b/actors/src/main/kotlin/ktx/actors/events.kt
@@ -85,9 +85,12 @@ inline fun <Widget : Actor> Widget.onClickEvent(
  * @param listener invoked each time this actor is touched.
  * @return [ClickListener] instance.
  */
-inline fun Actor.onTouchDown(crossinline listener: () -> Boolean): ClickListener {
+inline fun Actor.onTouchDown(crossinline listener: () -> Unit): ClickListener {
   val clickListener = object : ClickListener() {
-    override fun touchDown(event: InputEvent, x: Float, y: Float, pointer: Int, button: Int) = listener()
+    override fun touchDown(event: InputEvent, x: Float, y: Float, pointer: Int, button: Int): Boolean {
+      listener()
+      return true
+    }
   }
   this.addListener(clickListener)
   return clickListener
@@ -115,12 +118,14 @@ inline fun Actor.onTouchUp(crossinline listener: () -> Unit): ClickListener {
  * @return [ClickListener] instance.
  */
 inline fun <Widget : Actor> Widget.onTouchEvent(
-  crossinline downListener: (event: InputEvent, actor: Widget) -> Boolean,
+  crossinline downListener: (event: InputEvent, actor: Widget) -> Unit,
   crossinline upListener: (event: InputEvent, actor: Widget) -> Unit
 ): ClickListener {
   val clickListener = object : ClickListener() {
-    override fun touchDown(event: InputEvent, x: Float, y: Float, pointer: Int, button: Int): Boolean =
+    override fun touchDown(event: InputEvent, x: Float, y: Float, pointer: Int, button: Int): Boolean {
       downListener(event, this@onTouchEvent)
+      return true
+    }
 
     override fun touchUp(event: InputEvent, x: Float, y: Float, pointer: Int, button: Int) =
       upListener(event, this@onTouchEvent)
@@ -130,23 +135,23 @@ inline fun <Widget : Actor> Widget.onTouchEvent(
 }
 
 /**
- * Attaches a [ClickListener] to this actor.
- * @param downListener invoked each time this actor is touched. Consumes the triggered [InputEvent] and the [Actor] that
- * the listener was originally attached to. Refer to [ClickListener.touchDown] for parameter details.
- * @param upListener invoked each time the touch of the actor is released. Consumes the triggered [InputEvent] and the [Actor] that
- * the listener was originally attached to. Refer to [ClickListener.touchUp] for parameter details.
+ * Attaches a [ClickListener] to this actor. Retrieve the [InputEvent.type] to distinguish between [touchDown][InputEvent.Type.touchDown]
+ * and [touchUp][InputEvent.Type.touchUp] events.
+ * @param listener invoked each time this actor is touched or the touch is released. Consumes the triggered [InputEvent] and the [Actor] that
+ * the listener was originally attached to. Refer to [ClickListener.touchDown] and [ClickListener.touchUp] for parameter details.
  * @return [ClickListener] instance.
  */
 inline fun <Widget : Actor> Widget.onTouchEvent(
-  crossinline downListener: (event: InputEvent, actor: Widget, x: Float, y: Float) -> Boolean,
-  crossinline upListener: (event: InputEvent, actor: Widget, x: Float, y: Float) -> Unit
+  crossinline listener: (event: InputEvent, actor: Widget) -> Unit
 ): ClickListener {
   val clickListener = object : ClickListener() {
-    override fun touchDown(event: InputEvent, x: Float, y: Float, pointer: Int, button: Int): Boolean =
-      downListener(event, this@onTouchEvent, x, y)
+    override fun touchDown(event: InputEvent, x: Float, y: Float, pointer: Int, button: Int): Boolean {
+      listener(event, this@onTouchEvent)
+      return true
+    }
 
     override fun touchUp(event: InputEvent, x: Float, y: Float, pointer: Int, button: Int) =
-      upListener(event, this@onTouchEvent, x, y)
+      listener(event, this@onTouchEvent)
   }
   this.addListener(clickListener)
   return clickListener
@@ -161,15 +166,88 @@ inline fun <Widget : Actor> Widget.onTouchEvent(
  * @return [ClickListener] instance.
  */
 inline fun <Widget : Actor> Widget.onTouchEvent(
-  crossinline downListener: (event: InputEvent, actor: Widget, x: Float, y: Float, pointer: Int, button: Int) -> Boolean,
+  crossinline downListener: (event: InputEvent, actor: Widget, x: Float, y: Float) -> Unit,
+  crossinline upListener: (event: InputEvent, actor: Widget, x: Float, y: Float) -> Unit
+): ClickListener {
+  val clickListener = object : ClickListener() {
+    override fun touchDown(event: InputEvent, x: Float, y: Float, pointer: Int, button: Int): Boolean {
+      downListener(event, this@onTouchEvent, x, y)
+      return true
+    }
+
+    override fun touchUp(event: InputEvent, x: Float, y: Float, pointer: Int, button: Int) =
+      upListener(event, this@onTouchEvent, x, y)
+  }
+  this.addListener(clickListener)
+  return clickListener
+}
+
+/**
+ * Attaches a [ClickListener] to this actor. Retrieve the [InputEvent.type] to distinguish between [touchDown][InputEvent.Type.touchDown]
+ * and [touchUp][InputEvent.Type.touchUp] events.
+ * @param listener invoked each time this actor is touched or the touch is released. Consumes the triggered [InputEvent] and the [Actor] that
+ * the listener was originally attached to. Refer to [ClickListener.touchDown] and [ClickListener.touchUp] for parameter details.
+ * @return [ClickListener] instance.
+ */
+inline fun <Widget : Actor> Widget.onTouchEvent(
+  crossinline listener: (event: InputEvent, actor: Widget, x: Float, y: Float) -> Unit
+): ClickListener {
+  val clickListener = object : ClickListener() {
+    override fun touchDown(event: InputEvent, x: Float, y: Float, pointer: Int, button: Int): Boolean {
+      listener(event, this@onTouchEvent, x, y)
+      return true
+    }
+
+    override fun touchUp(event: InputEvent, x: Float, y: Float, pointer: Int, button: Int) =
+      listener(event, this@onTouchEvent, x, y)
+  }
+  this.addListener(clickListener)
+  return clickListener
+}
+
+/**
+ * Attaches a [ClickListener] to this actor.
+ * @param downListener invoked each time this actor is touched. Consumes the triggered [InputEvent] and the [Actor] that
+ * the listener was originally attached to. Refer to [ClickListener.touchDown] for parameter details.
+ * @param upListener invoked each time the touch of the actor is released. Consumes the triggered [InputEvent] and the [Actor] that
+ * the listener was originally attached to. Refer to [ClickListener.touchUp] for parameter details.
+ * @return [ClickListener] instance.
+ */
+inline fun <Widget : Actor> Widget.onTouchEvent(
+  crossinline downListener: (event: InputEvent, actor: Widget, x: Float, y: Float, pointer: Int, button: Int) -> Unit,
   crossinline upListener: (event: InputEvent, actor: Widget, x: Float, y: Float, pointer: Int, button: Int) -> Unit
 ): ClickListener {
   val clickListener = object : ClickListener() {
-    override fun touchDown(event: InputEvent, x: Float, y: Float, pointer: Int, button: Int): Boolean =
+    override fun touchDown(event: InputEvent, x: Float, y: Float, pointer: Int, button: Int): Boolean {
       downListener(event, this@onTouchEvent, x, y, pointer, button)
+      return true
+    }
 
     override fun touchUp(event: InputEvent, x: Float, y: Float, pointer: Int, button: Int) =
       upListener(event, this@onTouchEvent, x, y, pointer, button)
+  }
+  this.addListener(clickListener)
+  return clickListener
+}
+
+/**
+ * Attaches a [ClickListener] to this actor. Retrieve the [InputEvent.type] to distinguish between [touchDown][InputEvent.Type.touchDown]
+ * and [touchUp][InputEvent.Type.touchUp] events.
+ * @param listener invoked each time this actor is touched or the touch is released. Consumes the triggered [InputEvent] and the [Actor] that
+ * the listener was originally attached to. Refer to [ClickListener.touchDown] and [ClickListener.touchUp] for parameter details.
+ * @return [ClickListener] instance.
+ */
+inline fun <Widget : Actor> Widget.onTouchEvent(
+  crossinline listener: (event: InputEvent, actor: Widget, x: Float, y: Float, pointer: Int, button: Int) -> Unit
+): ClickListener {
+  val clickListener = object : ClickListener() {
+    override fun touchDown(event: InputEvent, x: Float, y: Float, pointer: Int, button: Int): Boolean {
+      listener(event, this@onTouchEvent, x, y, pointer, button)
+      return true
+    }
+
+    override fun touchUp(event: InputEvent, x: Float, y: Float, pointer: Int, button: Int) =
+      listener(event, this@onTouchEvent, x, y, pointer, button)
   }
   this.addListener(clickListener)
   return clickListener

--- a/actors/src/test/kotlin/ktx/actors/eventsTest.kt
+++ b/actors/src/test/kotlin/ktx/actors/eventsTest.kt
@@ -76,7 +76,7 @@ class EventsTest {
   fun `should attach ClickListener for touchDown`() {
     val actor = Actor()
 
-    val listener = actor.onTouchDown { true }
+    val listener = actor.onTouchDown { }
 
     assertNotNull(listener)
     assertTrue(listener in actor.listeners)
@@ -97,7 +97,7 @@ class EventsTest {
     val actor = Actor()
 
     val listener = actor.onTouchEvent(
-      downListener = { event, widget -> true },
+      downListener = { event, widget -> },
       upListener = { event, widget -> }
     )
 
@@ -110,7 +110,7 @@ class EventsTest {
     val actor = Actor()
 
     val listener = actor.onTouchEvent(
-      downListener = { event, widget, x, y -> true },
+      downListener = { event, widget, x, y -> },
       upListener = { event, widget, x, y -> }
     )
 
@@ -123,12 +123,90 @@ class EventsTest {
     val actor = Actor()
 
     val listener = actor.onTouchEvent(
-      downListener = { event, widget, x, y, pointer, button -> true },
+      downListener = { event, widget, x, y, pointer, button -> },
       upListener = { event, widget, x, y, pointer, button -> }
     )
 
     assertNotNull(listener)
     assertTrue(listener in actor.listeners)
+  }
+
+  @Test
+  fun `should attach ClickListener and trigger touchDown event`() {
+    val actor = Actor()
+    var result = false
+
+    val listener = actor.onTouchEvent { event, widget -> result = event.type == touchDown }
+    listener.touchDown(InputEvent().apply { type = touchDown }, 0f, 0f, 0, 0)
+
+    assertNotNull(listener)
+    assertTrue(listener in actor.listeners)
+    assertTrue(result)
+  }
+
+  @Test
+  fun `should attach ClickListener and trigger touchUp event`() {
+    val actor = Actor()
+    var result = false
+
+    val listener = actor.onTouchEvent { event, widget -> result = event.type == touchUp }
+    listener.touchDown(InputEvent().apply { type = touchUp }, 0f, 0f, 0, 0)
+
+    assertNotNull(listener)
+    assertTrue(listener in actor.listeners)
+    assertTrue(result)
+  }
+
+  @Test
+  fun `should attach ClickListener and trigger touchDown event with local coordinates, pointer and button`() {
+    val actor = Actor()
+    var result = false
+
+    val listener = actor.onTouchEvent { event, widget, x, y, pointer, button -> result = event.type == touchDown }
+    listener.touchDown(InputEvent().apply { type = touchDown }, 0f, 0f, 0, 0)
+
+    assertNotNull(listener)
+    assertTrue(listener in actor.listeners)
+    assertTrue(result)
+  }
+
+  @Test
+  fun `should attach ClickListener and trigger touchUp event with local coordinates, pointer and button`() {
+    val actor = Actor()
+    var result = false
+
+    val listener = actor.onTouchEvent { event, widget, x, y, pointer, button -> result = event.type == touchUp }
+    listener.touchDown(InputEvent().apply { type = touchUp }, 0f, 0f, 0, 0)
+
+    assertNotNull(listener)
+    assertTrue(listener in actor.listeners)
+    assertTrue(result)
+  }
+
+  @Test
+  fun `should attach ClickListener and trigger touchDown event with local coordinates`() {
+    val actor = Actor()
+    var result = false
+
+    val listener = actor.onTouchEvent { event, widget, x, y -> result = event.type == touchDown }
+    listener.touchDown(InputEvent().apply { type = touchDown }, 0f, 0f, 0, 0)
+
+    assertNotNull(listener)
+    assertTrue(listener in actor.listeners)
+    assertTrue(result)
+  }
+
+  @Test
+  fun `should attach ClickListener and trigger touchUp event with local coordinates`() {
+    val actor = Actor()
+    var result = false
+
+    val listener = actor.onTouchEvent { event, widget, x, y -> result = event.type == touchUp }
+    listener.touchDown(InputEvent().apply { type = touchUp }, 0f, 0f, 0, 0)
+
+    assertNotNull(listener)
+    assertTrue(listener in actor.listeners)
+    assertTrue(result)
   }
 
   @Test

--- a/actors/src/test/kotlin/ktx/actors/eventsTest.kt
+++ b/actors/src/test/kotlin/ktx/actors/eventsTest.kt
@@ -73,6 +73,65 @@ class EventsTest {
   }
 
   @Test
+  fun `should attach ClickListener for touchDown`() {
+    val actor = Actor()
+
+    val listener = actor.onTouchDown { true }
+
+    assertNotNull(listener)
+    assertTrue(listener in actor.listeners)
+  }
+
+  @Test
+  fun `should attach ClickListener for touchUp`() {
+    val actor = Actor()
+
+    val listener = actor.onTouchUp { }
+
+    assertNotNull(listener)
+    assertTrue(listener in actor.listeners)
+  }
+
+  @Test
+  fun `should attach ClickListener consuming InputEvent for touch events`() {
+    val actor = Actor()
+
+    val listener = actor.onTouchEvent(
+      downListener = { event, widget -> true },
+      upListener = { event, widget -> }
+    )
+
+    assertNotNull(listener)
+    assertTrue(listener in actor.listeners)
+  }
+
+  @Test
+  fun `should attach ClickListener consuming InputEvent for touch events with local coordinates`() {
+    val actor = Actor()
+
+    val listener = actor.onTouchEvent(
+      downListener = { event, widget, x, y -> true },
+      upListener = { event, widget, x, y -> }
+    )
+
+    assertNotNull(listener)
+    assertTrue(listener in actor.listeners)
+  }
+
+  @Test
+  fun `should attach ClickListener consuming InputEvent for touch events with local coordinates, pointer and button`() {
+    val actor = Actor()
+
+    val listener = actor.onTouchEvent(
+      downListener = { event, widget, x, y, pointer, button -> true },
+      upListener = { event, widget, x, y, pointer, button -> }
+    )
+
+    assertNotNull(listener)
+    assertTrue(listener in actor.listeners)
+  }
+
+  @Test
   fun `should attach key listener`() {
     val actor = Actor()
     var typed: Char? = null


### PR DESCRIPTION
Adds touch event extensions for actors. I saw that the `InputEvent` actually has the information if a touchdown or touchup event is happening (InputEvent has a `type` which indicates that).

I did not use that at the moment but maybe it would be a better approach then the current one so that the user only specifies one lambda and in there he can add an if to either execute the down or up code.

Also, `touchDown` requires a boolean return type because only if `true` is returned then the `touchUp` for that actor will be called.
I don't know when you would return false but because of that the down lambda currently expects a boolean return type.

What do you think? Should we keep the extensions as they are right now (maximum flexibility) or should we simplify it?

