### PR TITLE
RenderScope() factory function

### DIFF
--- a/async/README.md
+++ b/async/README.md
@@ -50,6 +50,9 @@ Before using `KtxAsync` scope, make sure to call `KtxAsync.initiate()` on the ma
 strictly required if immediate dispatcher is not used, but as a rule of thumb, you should invoke this method in `create`
 of your `ApplicationListener`.
 
+The `RenderScope()` factory function is the KTX rendering-thread version of `MainScope()`. It creates a scope to launch
+coroutines in the rendering thread and that has a supervisor job so the whole scope can be cancelled at once.
+
 KTX providers 2 main implementations of coroutine dispatchers:
 
 * `RenderingThreadDispatcher`: executes tasks on the main rendering thread. Available via `Dispatchers.KTX`. Default
@@ -298,6 +301,28 @@ fun withCancel() {
         println("Should not execute this.")
     }
     job.cancel()
+}
+```
+
+Creating a coroutine scope to confine jobs' lives to a specific class:
+
+```Kotlin
+import kotlinx.coroutines.launch
+import ktx.async.httpRequest
+import ktx.async.RenderScope
+
+class MyScreen: Screen, CoroutineScope by RenderScope() {
+
+    //...
+
+    override fun hide() {
+        cancel() // cancel any running coroutines when leaving screen
+    }
+    
+    private fun loadSomething() = launch { // Start coroutine in this screen's scope
+        val result = httpRequest(url = "https://example.com")
+        webResultLabel.text = result.contentAsString
+    }
 }
 ```
 

--- a/async/src/main/kotlin/ktx/async/async.kt
+++ b/async/src/main/kotlin/ktx/async/async.kt
@@ -7,6 +7,7 @@ import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.suspendCancellableCoroutine
 import kotlinx.coroutines.withContext
+import kotlinx.coroutines.SupervisorJob
 import kotlin.coroutines.ContinuationInterceptor
 import kotlin.coroutines.resume
 
@@ -31,6 +32,12 @@ object KtxAsync : CoroutineScope {
 @Suppress("unused")
 val Dispatchers.KTX
   get() = MainDispatcher
+
+/**
+ * Creates a coroutine scope in the rendering thread with a supervisor job. An alternative to the global [KtxAsync].
+ */
+@Suppress("FunctionName")
+fun RenderScope() = CoroutineScope(SupervisorJob() + MainDispatcher)
 
 /**
  * Creates a new [AsyncExecutorDispatcher] wrapping around an [AsyncExecutor] with a single thread to execute tasks

--- a/async/src/test/kotlin/ktx/async/asyncTest.kt
+++ b/async/src/test/kotlin/ktx/async/asyncTest.kt
@@ -5,6 +5,7 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.GlobalScope
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
+import kotlinx.coroutines.cancel
 import org.junit.Assert.*
 import org.junit.Test
 import java.util.concurrent.CompletableFuture
@@ -190,4 +191,28 @@ class KtxAsyncTest : AsyncTest() {
     assertNotSame(getMainRenderingThread(), executionThread.join())
     assertFalse(isOnRenderingThread.get())
   }
+
+  @Test
+  fun `should create non-global scope`() {
+    // Given:
+    val scope = RenderScope()
+    val localJob = scope.launch {
+      while (true) {
+        delay(50)
+      }
+    }
+    val globalJob = KtxAsync.launch {
+      while (true) {
+        delay(50)
+      }
+    }
+
+    // When:
+    scope.cancel()
+
+    // Then:
+    assert(localJob.isCancelled)
+    assert(globalJob.isActive)
+  }
+
 }


### PR DESCRIPTION
Felt like this was missing. Not sure if it should be called `KtxScope()` for naming consistency, or if that makes it too vague.