### PR TITLE
Make Context.register a non-inlined function…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 #### 1.9.10-SNAPSHOT
 
 - **[FEATURE]** (`ktx-async`) Added `RenderingScope` factory function for custom scopes using rendering thread dispatcher.
+- **[MISC]** (`ktx-inject`) `Context.register` is not inlined anymore, so it can be mocked in tests and the bindings lambda stops being run.
 
 #### 1.9.10-b4
 

--- a/inject/src/main/kotlin/ktx/inject/inject.kt
+++ b/inject/src/main/kotlin/ktx/inject/inject.kt
@@ -118,7 +118,7 @@ open class Context : Disposable {
    * @see bind
    * @see bindSingleton
    */
-  inline fun register(init: Context.() -> Unit): Context {
+   fun register(init: Context.() -> Unit): Context {
     this.init()
     return this
   }


### PR DESCRIPTION
… so it can be mocked in tests and the bindings lambda stops being run