### PR TITLE
DisposableRegistry

### DIFF
--- a/assets/README.md
+++ b/assets/README.md
@@ -80,6 +80,13 @@ collections of assets en masse.
 - All exceptions get a utility `ignore()` method that you can switch at compile time (for debugging or logging) when
 needed. See `Throwable.ignore()` documentation for further details.
 
+#### `DisposableContainer`
+
+- `DisposableContainer` is a `Disposable` that references a set of `Disposable` instances to be disposed all at once.
+When subclassed or used as a delegate via its `DisposableRegistry` interface, it provides an `alsoRegister` extension 
+which allows easily adding items to the container when instantiating them so they'll automatically be disposed when
+the containing class is.
+
 #### `Pool`
 
 - `Pool` instances can be invoked like a function to provide new instances of objects. Basically, this syntax: `pool()`
@@ -155,6 +162,33 @@ val textures: Array<Texture> = getMyTextures() // Works with any Iterable, too!
 textures.dispose() // Throws exceptions.
 textures.disposeSafely() // Ignores exceptions.
 textures.dispose { exception -> } // Allows to handle exceptions.
+```
+
+Registering `Disposable`s for disposal when the containing class is disposed:
+```Kotlin
+import ktx.assets.*
+
+class MyScreen: Screen, DisposableRegistry by DisposableContainer() {
+  val assetManager = AssetManager().alsoRegister()
+  val spriteBatch = SpriteBatch().alsoRegister()
+  // ...
+}
+```
+
+Disposing registered `Disposable`s in a class with its own non-abstract `dispose()` method:
+```Kotlin
+import ktx.assets.*
+
+class MyScreen: ScreenAdapter, DisposableRegistry by DisposableContainer() {
+  val assetManager = AssetManager().alsoRegister()
+  val spriteBatch = SpriteBatch().alsoRegister()
+
+  override fun dispose() {
+    // ScreenAdapter's dispose() hides DisposableRegistry.dispose(), so registry
+    // disposal should be done manually.
+    registeredDisposables.dispose()
+  }
+}
 ```
 
 Scheduling assets loading by an `AssetManager`:

--- a/assets/src/main/kotlin/ktx/assets/disposables.kt
+++ b/assets/src/main/kotlin/ktx/assets/disposables.kt
@@ -114,9 +114,9 @@ inline fun Throwable?.ignore() {
 interface DisposableRegistry : Disposable {
 
   /**
-   * A copy of the of the registered Disposables.
+   * A copy of the registered Disposables. The order does not necessarily represent the registration order.
    */
-  val registeredDisposables: Set<Disposable>
+  val registeredDisposables: List<Disposable>
 
   /**
    * Registers [disposable] with this registry.
@@ -168,7 +168,7 @@ open class DisposableContainer : DisposableRegistry {
 
   private val registry: MutableSet<Disposable> = Collections.newSetFromMap(IdentityHashMap())
 
-  override val registeredDisposables: Set<Disposable> get() = registry.toSet()
+  override val registeredDisposables: List<Disposable> get() = registry.toList()
 
   override fun register(disposable: Disposable): Boolean = registry.add(disposable)
 

--- a/assets/src/main/kotlin/ktx/assets/disposables.kt
+++ b/assets/src/main/kotlin/ktx/assets/disposables.kt
@@ -1,9 +1,8 @@
 package ktx.assets
 
 import com.badlogic.gdx.utils.Disposable
-import com.badlogic.gdx.utils.IdentityMap
-import com.badlogic.gdx.utils.ObjectSet
-import java.util.*
+import java.util.Collections
+import java.util.IdentityHashMap
 import kotlin.contracts.ExperimentalContracts
 import kotlin.contracts.InvocationKind
 import kotlin.contracts.contract
@@ -175,8 +174,11 @@ open class DisposableContainer : DisposableRegistry {
 
   override fun deregister(disposable: Disposable): Boolean = registry.remove(disposable)
 
-  override fun deregisterAll(): Boolean = registry.isNotEmpty().also { registry.clear() }
+  override fun deregisterAll(): Boolean {
+    val hadItems = registry.isNotEmpty()
+    registry.clear()
+    return hadItems
+  }
 
   override fun dispose() = registry.forEach(Disposable::dispose)
-
 }

--- a/assets/src/main/kotlin/ktx/assets/disposables.kt
+++ b/assets/src/main/kotlin/ktx/assets/disposables.kt
@@ -112,7 +112,7 @@ inline fun Throwable?.ignore() {
  * The existing implementation [DisposableContainer] can be attached to a class as a delegate to
  * attach these convenience functions to any class.
  */
-interface DisposableRegistry: Disposable {
+interface DisposableRegistry : Disposable {
 
   /**
    * A copy of the of the registered Disposables.

--- a/assets/src/test/kotlin/ktx/assets/DisposablesTest.kt
+++ b/assets/src/test/kotlin/ktx/assets/DisposablesTest.kt
@@ -3,13 +3,8 @@ package ktx.assets
 import com.badlogic.gdx.utils.Array as GdxArray
 import com.badlogic.gdx.utils.Disposable
 import com.badlogic.gdx.utils.GdxRuntimeException
-import com.nhaarman.mockitokotlin2.doThrow
-import com.nhaarman.mockitokotlin2.mock
-import com.nhaarman.mockitokotlin2.verify
-import com.nhaarman.mockitokotlin2.verifyZeroInteractions
-import org.junit.Assert.assertNull
-import org.junit.Assert.assertSame
-import org.junit.Assert.fail
+import com.nhaarman.mockitokotlin2.*
+import org.junit.Assert.*
 import org.junit.Test
 
 /**
@@ -167,4 +162,85 @@ class DisposablesTest {
 
     verifyZeroInteractions(exception)
   }
+
+  @Test
+  fun `should register disposables`() {
+    class Parent: DisposableRegistry by DisposableContainer() {
+      val disposableA = mock<Disposable>()
+      init {
+        val initialSuccess = register(disposableA)
+        assertTrue(initialSuccess)
+      }
+      val disposableB = mock<Disposable>().alsoRegister()
+    }
+    val instance = Parent()
+    val disposables = listOf(instance.disposableA, instance.disposableB)
+    val registered = instance.registeredDisposables
+    assertTrue(registered.containsAll(disposables))
+    assertTrue(registered.size == 2)
+
+    val repeatedSuccess = instance.register(instance.disposableA)
+    assertFalse(repeatedSuccess)
+  }
+
+  @Test
+  fun `should deregister disposables`() {
+    class Parent: DisposableRegistry by DisposableContainer() {
+      val disposableA = mock<Disposable>().alsoRegister()
+      val disposableB = mock<Disposable>().alsoRegister()
+      fun deregisterB() = disposableB.alsoDeregister()
+    }
+    val instance = Parent()
+    val initialSuccess = instance.deregister(instance.disposableA)
+    assertTrue(initialSuccess)
+    instance.deregisterB()
+    assertTrue(instance.registeredDisposables.isEmpty())
+    instance.dispose()
+    verify(instance.disposableA, never()).dispose()
+    verify(instance.disposableB, never()).dispose()
+    val repeatedSuccess = instance.deregister(instance.disposableA)
+    assertFalse(repeatedSuccess)
+  }
+
+  @Test
+  fun `should deregister all disposables`() {
+    class Parent: DisposableRegistry by DisposableContainer() {
+      val disposableA = mock<Disposable>().alsoRegister()
+      val disposableB = mock<Disposable>().alsoRegister()
+    }
+    val instance = Parent()
+    val initialSuccess = instance.deregisterAll()
+    assertTrue(initialSuccess)
+    assertTrue(instance.registeredDisposables.isEmpty())
+    instance.dispose()
+    verify(instance.disposableA, never()).dispose()
+    verify(instance.disposableB, never()).dispose()
+    val repeatedSuccess = instance.deregisterAll()
+    assertFalse(repeatedSuccess)
+  }
+
+  @Test
+  fun `should dispose registered disposables`() {
+    class Parent: DisposableRegistry by DisposableContainer() {
+      val disposableA = mock<Disposable>().alsoRegister()
+      val disposableB = mock<Disposable>().alsoRegister()
+    }
+    val instance = Parent()
+    instance.dispose()
+    verify(instance.disposableA).dispose()
+    verify(instance.disposableB).dispose()
+  }
+
+  @Test
+  fun `should safely dispose registered disposables`() {
+    class Parent: DisposableRegistry by DisposableContainer() {
+      val disposable = mock<Disposable> {
+        on(it.dispose()) doThrow GdxRuntimeException("Expected.")
+      }.alsoRegister()
+    }
+    val instance = Parent()
+    instance.disposeSafely() // Should not throw any exceptions.
+    verify(instance.disposable).dispose()
+  }
+
 }

--- a/assets/src/test/kotlin/ktx/assets/DisposablesTest.kt
+++ b/assets/src/test/kotlin/ktx/assets/DisposablesTest.kt
@@ -165,14 +165,17 @@ class DisposablesTest {
 
   @Test
   fun `should register disposables`() {
-    class Parent: DisposableRegistry by DisposableContainer() {
+    class Parent : DisposableRegistry by DisposableContainer() {
       val disposableA = mock<Disposable>()
+
       init {
         val initialSuccess = register(disposableA)
         assertTrue(initialSuccess)
       }
+
       val disposableB = mock<Disposable>().alsoRegister()
     }
+
     val instance = Parent()
     val disposables = listOf(instance.disposableA, instance.disposableB)
     val registered = instance.registeredDisposables
@@ -185,11 +188,12 @@ class DisposablesTest {
 
   @Test
   fun `should deregister disposables`() {
-    class Parent: DisposableRegistry by DisposableContainer() {
+    class Parent : DisposableRegistry by DisposableContainer() {
       val disposableA = mock<Disposable>().alsoRegister()
       val disposableB = mock<Disposable>().alsoRegister()
       fun deregisterB() = disposableB.alsoDeregister()
     }
+
     val instance = Parent()
     val initialSuccess = instance.deregister(instance.disposableA)
     assertTrue(initialSuccess)
@@ -204,10 +208,11 @@ class DisposablesTest {
 
   @Test
   fun `should deregister all disposables`() {
-    class Parent: DisposableRegistry by DisposableContainer() {
+    class Parent : DisposableRegistry by DisposableContainer() {
       val disposableA = mock<Disposable>().alsoRegister()
       val disposableB = mock<Disposable>().alsoRegister()
     }
+
     val instance = Parent()
     val initialSuccess = instance.deregisterAll()
     assertTrue(initialSuccess)
@@ -221,10 +226,11 @@ class DisposablesTest {
 
   @Test
   fun `should dispose registered disposables`() {
-    class Parent: DisposableRegistry by DisposableContainer() {
+    class Parent : DisposableRegistry by DisposableContainer() {
       val disposableA = mock<Disposable>().alsoRegister()
       val disposableB = mock<Disposable>().alsoRegister()
     }
+
     val instance = Parent()
     instance.dispose()
     verify(instance.disposableA).dispose()
@@ -233,11 +239,12 @@ class DisposablesTest {
 
   @Test
   fun `should safely dispose registered disposables`() {
-    class Parent: DisposableRegistry by DisposableContainer() {
+    class Parent : DisposableRegistry by DisposableContainer() {
       val disposable = mock<Disposable> {
         on(it.dispose()) doThrow GdxRuntimeException("Expected.")
       }.alsoRegister()
     }
+
     val instance = Parent()
     instance.disposeSafely() // Should not throw any exceptions.
     verify(instance.disposable).dispose()

--- a/assets/src/test/kotlin/ktx/assets/DisposablesTest.kt
+++ b/assets/src/test/kotlin/ktx/assets/DisposablesTest.kt
@@ -3,8 +3,17 @@ package ktx.assets
 import com.badlogic.gdx.utils.Array as GdxArray
 import com.badlogic.gdx.utils.Disposable
 import com.badlogic.gdx.utils.GdxRuntimeException
-import com.nhaarman.mockitokotlin2.*
-import org.junit.Assert.*
+import com.nhaarman.mockitokotlin2.doThrow
+import com.nhaarman.mockitokotlin2.mock
+import com.nhaarman.mockitokotlin2.never
+import com.nhaarman.mockitokotlin2.verify
+import com.nhaarman.mockitokotlin2.verifyZeroInteractions
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertSame
+import org.junit.Assert.assertTrue
+import org.junit.Assert.fail
 import org.junit.Test
 
 /**
@@ -177,10 +186,7 @@ class DisposablesTest {
     }
 
     val instance = Parent()
-    val disposables = listOf(instance.disposableA, instance.disposableB)
-    val registered = instance.registeredDisposables
-    assertTrue(registered.containsAll(disposables))
-    assertTrue(registered.size == 2)
+    assertEquals(instance.registeredDisposables, setOf(instance.disposableA, instance.disposableB))
 
     val repeatedSuccess = instance.register(instance.disposableA)
     assertFalse(repeatedSuccess)
@@ -249,5 +255,4 @@ class DisposablesTest {
     instance.disposeSafely() // Should not throw any exceptions.
     verify(instance.disposable).dispose()
   }
-
 }


### PR DESCRIPTION
This is a tool I've been using lately to make it easy to keep track of all the Disposable instances stored in fields of a class so I won't miss disposing of them.

The way I use it is by instantiating a concrete implementation as a delegate. This exposes an `.alsoRegister()` extension function for Disposables so they can be registered right where you instantiate them. Then they are easy to dispose all together. Example:

```kotlin
class MyLoadScreen: Screen, DisposableRegistry by DisposableContainer() {
    private val batch = SpriteBatch().alsoRegister()
    private val logoTexture = Texture("myLogo.png", true).apply {
        setFilter(TextureFilter.Linear, TextureFilter.MipMapLinearLinear)
        alsoRegister()
    }

    //...

    override fun dispose() {
        disposeRegisteredSafely()
    }
}
```

The reason for the interface is to allow you to use it as a delegate so you don't have to subclass it to get the extension functions for Disposable. But subclassing is still an option.

If this sounds like a good fit for Ktx, I can flesh this out with tests and documentation.