### PR TITLE
isEmpty, isNotEmpty and forEachLayer for ktx-tiled

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 _See also: [the official LibGDX changelog](https://github.com/libgdx/libgdx/blob/master/CHANGES)._
 
 #### 1.9.14-SNAPSHOT
+- **[FEATURE]** (`ktx-tiled`) Added `isEmpty` and `isNotEmpty` extension function for `MapLayers` and `MapObjects` collections.
+- **[FEATURE]** (`ktx-tiled`) Added `forEachLayer` extension function for `TiledMap` to iterate over an exact type 
+  of `MapLayer` instances of a specific map
 
 #### 1.9.14-b1
 

--- a/tiled/README.md
+++ b/tiled/README.md
@@ -103,11 +103,11 @@ val map: TiledMap = getMap()
 val myFloatProp: Float = mapObj.property("myFloatProperty")
 
 // Retrieves String property with a default value:
-val myProp: String = mapObj.property("myProperty", defaultValue="")
+val myProp: String = mapObj.property("myProperty", defaultValue = "")
 
 // The explicit type can be omitted as it is automatically derived from the type of the default value.
 // myProp2 is of type Float
-val myProp2 = mapLayer.property("myProperty2", defaultValue=1f)
+val myProp2 = mapLayer.property("myProperty2", defaultValue = 1f)
 
 // Retrieves Int property or null if the property does not exist.
 val myOtherProp: Int? = map.propertyOrNull("myOtherProperty")
@@ -200,8 +200,8 @@ if(map.contains("enemyLayer")) {
 }
 
 // or with the "in" syntax
-if("collision" in map) {
-    val collisionLayer = map.layer("collision")    
+if ("collision" in map) {
+    val collisionLayer = map.layer("collision")
 }
 
 // the next line will throw a MissingLayerException if the layer does not exist
@@ -232,7 +232,8 @@ val map: TiledMap = getTiledMap()
 
 // Iterate over all object layers and parse them.
 // Note that parseObjectLayer is only called for layers of exact type MapLayer.
-// TiledMapTileLayer which is a subclass of MapLayer will not match.
+// For example, TiledMapTileLayer - which is a subclass of MapLayer - does not 
+// have this exact type and will not match.
 map.forEachLayer<MapLayer> { layer ->
     parseObjectLayer(layer)
 }
@@ -242,19 +243,18 @@ Check if a `MapLayers` or `MapObjects` collection is empty:
 
 ```kotlin
 import com.badlogic.gdx.maps.MapObjects
-import com.badlogic.gdx.maps.MapLayers
 import com.badlogic.gdx.maps.tiled.TiledMap
 import ktx.tiled.*
 
-val map: TiledMap = getTiledMap()
+val map: TiledMap = TiledMap()
 
-if(tiledMap.layers.isNotEmpty()) {
-    tiledMap.layers.forEach { layer ->
-        if(layer.objects.isEmpty()) {
+if (map.layers.isNotEmpty()) {
+    map.layers.forEach { layer ->
+        if (layer.objects.isEmpty()) {
             // nothing to do if there are no objects
             return@forEach
         }
-        
+
         parseObjects(layer.objects)
     }
 }

--- a/tiled/README.md
+++ b/tiled/README.md
@@ -73,8 +73,15 @@ the following extensions were added:
 - `contains(layerName: String)`: works as the `in` operator.
 - `layer(layerName: String)`: returns the layer or throws a `MissingLayerException` in case the layer does not exist.
 
-Inlined `forEachMapObject` extension methods allows to iterate over all `MapObject` instances present on the chosen
+Inlined `forEachMapObject` extension method allows to iterate over all `MapObject` instances present on the chosen
 map layer.
+
+Inlined `forEachLayer` extension method allows to iterate over all `MapLayer` instances of a specific type to execute
+a certain function on them.
+
+### `MapLayers` and `MapObjects`
+
+`isEmpty` and `isNotEmpty` extension method to check if the specific collection is empty or not.
 
 ### Usage examples
 
@@ -212,6 +219,44 @@ val map: TiledMap = getTiledMap()
 // Creates collision bodies for every map object of the collision layer:
 map.forEachMapObject("collision") { mapObj ->
     createStaticBox2DCollisionBody(mapObj.x, mapObj.y, mapObj.shape)
+}
+```
+
+Iterating over a specific type of layers of a map:
+
+```kotlin
+import com.badlogic.gdx.maps.tiled.TiledMap
+import ktx.tiled.*
+
+val map: TiledMap = getTiledMap()
+
+// Iterate over all object layers and parse them.
+// Note that parseObjectLayer is only called for layers of exact type MapLayer.
+// TiledMapTileLayer which is a subclass of MapLayer will not match.
+map.forEachLayer<MapLayer> { layer ->
+    parseObjectLayer(layer)
+}
+```
+
+Check if a `MapLayers` or `MapObjects` collection is empty:
+
+```kotlin
+import com.badlogic.gdx.maps.MapObjects
+import com.badlogic.gdx.maps.MapLayers
+import com.badlogic.gdx.maps.tiled.TiledMap
+import ktx.tiled.*
+
+val map: TiledMap = getTiledMap()
+
+if(tiledMap.layers.isNotEmpty()) {
+    tiledMap.layers.forEach { layer ->
+        if(layer.objects.isEmpty()) {
+            // nothing to do if there are no objects
+            return@forEach
+        }
+        
+        parseObjects(layer.objects)
+    }
 }
 ```
 

--- a/tiled/src/main/kotlin/ktx/tiled/mapLayers.kt
+++ b/tiled/src/main/kotlin/ktx/tiled/mapLayers.kt
@@ -1,6 +1,7 @@
 package ktx.tiled
 
 import com.badlogic.gdx.maps.MapLayer
+import com.badlogic.gdx.maps.MapLayers
 import com.badlogic.gdx.maps.MapProperties
 
 /**
@@ -38,3 +39,13 @@ inline fun <reified T> MapLayer.propertyOrNull(key: String): T? = properties[key
  * @return true if the property exists. Otherwise false.
  */
 fun MapLayer.containsProperty(key: String) = properties.containsKey(key)
+
+/**
+ * Returns **true** if and only if the [MapLayers] collection is empty.
+ */
+fun MapLayers.isEmpty() = this.count <= 0
+
+/**
+ * Returns **true** if and only if the [MapLayers] collection is not empty.
+ */
+fun MapLayers.isNotEmpty() = this.count > 0

--- a/tiled/src/main/kotlin/ktx/tiled/mapObjects.kt
+++ b/tiled/src/main/kotlin/ktx/tiled/mapObjects.kt
@@ -1,6 +1,7 @@
 package ktx.tiled
 
 import com.badlogic.gdx.maps.MapObject
+import com.badlogic.gdx.maps.MapObjects
 import com.badlogic.gdx.maps.MapProperties
 import com.badlogic.gdx.maps.objects.CircleMapObject
 import com.badlogic.gdx.maps.objects.EllipseMapObject
@@ -120,3 +121,13 @@ val MapObject.shape: Shape2D
     is RectangleMapObject -> rectangle
     else -> throw MissingShapeException("MapObject of type ${this::class.java} does not have a shape.")
   }
+
+/**
+ * Returns **true** if and only if the [MapObjects] collection is empty.
+ */
+fun MapObjects.isEmpty() = this.count <= 0
+
+/**
+ * Returns **true** if and only if the [MapObjects] collection is not empty.
+ */
+fun MapObjects.isNotEmpty() = this.count > 0

--- a/tiled/src/main/kotlin/ktx/tiled/tiledMaps.kt
+++ b/tiled/src/main/kotlin/ktx/tiled/tiledMaps.kt
@@ -156,16 +156,16 @@ inline fun TiledMap.forEachMapObject(layerName: String, action: (MapObject) -> U
 }
 
 /**
- * Extension method to run a [lambda] on a specific type of [layers][MapLayer] of the [TiledMap]. The lambda
+ * Extension method to run an [action] on a specific type of [layers][MapLayer] of the [TiledMap]. The lambda
  * takes the matching [MapLayer] as a parameter.
  *
  * The class matching is an exact match meaning that a given subclass like [TiledMapTileLayer] will not match
  * for the argument [MapLayer].
  */
-inline fun <reified T : MapLayer> TiledMap.forEachLayer(lambda: (T) -> Unit) {
+inline fun <reified T : MapLayer> TiledMap.forEachLayer(action: (T) -> Unit) {
   this.layers.forEach {
     if (it::class == T::class) {
-      lambda(it as T)
+      action(it as T)
     }
   }
 }

--- a/tiled/src/main/kotlin/ktx/tiled/tiledMaps.kt
+++ b/tiled/src/main/kotlin/ktx/tiled/tiledMaps.kt
@@ -4,6 +4,7 @@ import com.badlogic.gdx.maps.MapLayer
 import com.badlogic.gdx.maps.MapObject
 import com.badlogic.gdx.maps.MapProperties
 import com.badlogic.gdx.maps.tiled.TiledMap
+import com.badlogic.gdx.maps.tiled.TiledMapTileLayer
 
 /**
  * Extension method to directly access the [MapProperties] of a [TiledMap]. If the property
@@ -151,5 +152,20 @@ fun TiledMap.layer(layerName: String) = layers[layerName]
 inline fun TiledMap.forEachMapObject(layerName: String, action: (MapObject) -> Unit) {
   layers[layerName]?.objects?.forEach {
     action(it)
+  }
+}
+
+/**
+ * Extension method to run a [lambda] on a specific type of [layers][MapLayer] of the [TiledMap]. The lambda
+ * takes the matching [MapLayer] as a parameter.
+ *
+ * The class matching is an exact match meaning that a given subclass like [TiledMapTileLayer] will not match
+ * for the argument [MapLayer].
+ */
+inline fun <reified T : MapLayer> TiledMap.forEachLayer(lambda: (T) -> Unit) {
+  this.layers.forEach {
+    if (it::class == T::class) {
+      lambda(it as T)
+    }
   }
 }

--- a/tiled/src/test/kotlin/ktx/tiled/MapLayerTest.kt
+++ b/tiled/src/test/kotlin/ktx/tiled/MapLayerTest.kt
@@ -62,6 +62,15 @@ class MapLayerTest {
   }
 
   @Test
+  fun `should return true when MapLayers becomes empty`() {
+    val actual = MapLayers()
+    actual.add(MapLayer())
+    actual.remove(0)
+
+    assertTrue(actual.isEmpty())
+  }
+
+  @Test
   fun `should return true when MapLayers is not empty`() {
     val actual = MapLayers()
     actual.add(MapLayer())

--- a/tiled/src/test/kotlin/ktx/tiled/MapLayerTest.kt
+++ b/tiled/src/test/kotlin/ktx/tiled/MapLayerTest.kt
@@ -1,6 +1,7 @@
 package ktx.tiled
 
 import com.badlogic.gdx.maps.MapLayer
+import com.badlogic.gdx.maps.MapLayers
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertNull
@@ -43,5 +44,35 @@ class MapLayerTest {
   @Test(expected = MissingPropertyException::class)
   fun `should not retrieve non-existing property from MapLayer`() {
     mapLayer.property<String>("non-existing")
+  }
+
+  @Test
+  fun `should return true when MapLayers is empty`() {
+    val actual = MapLayers()
+
+    assertTrue(actual.isEmpty())
+  }
+
+  @Test
+  fun `should return false when MapLayers is not empty`() {
+    val actual = MapLayers()
+    actual.add(MapLayer())
+
+    assertFalse(actual.isEmpty())
+  }
+
+  @Test
+  fun `should return true when MapLayers is not empty`() {
+    val actual = MapLayers()
+    actual.add(MapLayer())
+
+    assertTrue(actual.isNotEmpty())
+  }
+
+  @Test
+  fun `should return false when MapLayers is empty`() {
+    val actual = MapLayers()
+
+    assertFalse(actual.isNotEmpty())
   }
 }

--- a/tiled/src/test/kotlin/ktx/tiled/MapObjectTest.kt
+++ b/tiled/src/test/kotlin/ktx/tiled/MapObjectTest.kt
@@ -1,6 +1,7 @@
 package ktx.tiled
 
 import com.badlogic.gdx.maps.MapObject
+import com.badlogic.gdx.maps.MapObjects
 import com.badlogic.gdx.maps.objects.CircleMapObject
 import com.badlogic.gdx.maps.objects.EllipseMapObject
 import com.badlogic.gdx.maps.objects.PolygonMapObject
@@ -118,5 +119,35 @@ class MapObjectTest {
     val textureObject = TextureMapObject()
 
     textureObject.shape
+  }
+
+  @Test
+  fun `should return true when MapObjects is empty`() {
+    val actual = MapObjects()
+
+    assertTrue(actual.isEmpty())
+  }
+
+  @Test
+  fun `should return false when MapObjects is not empty`() {
+    val actual = MapObjects()
+    actual.add(MapObject())
+
+    assertFalse(actual.isEmpty())
+  }
+
+  @Test
+  fun `should return true when MapObjects is not empty`() {
+    val actual = MapObjects()
+    actual.add(MapObject())
+
+    assertTrue(actual.isNotEmpty())
+  }
+
+  @Test
+  fun `should return false when MapObjects is empty`() {
+    val actual = MapObjects()
+
+    assertFalse(actual.isNotEmpty())
   }
 }

--- a/tiled/src/test/kotlin/ktx/tiled/TiledMapTest.kt
+++ b/tiled/src/test/kotlin/ktx/tiled/TiledMapTest.kt
@@ -3,6 +3,7 @@ package ktx.tiled
 import com.badlogic.gdx.maps.MapLayer
 import com.badlogic.gdx.maps.MapObject
 import com.badlogic.gdx.maps.tiled.TiledMap
+import com.badlogic.gdx.maps.tiled.TiledMapTileLayer
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertNull
@@ -123,5 +124,25 @@ class TiledMapTest {
     tiledMap.forEachMapObject("non-existing") {
       fail()
     }
+  }
+
+  @Test
+  fun `should not execute lambda when there is no layer for the given type`() {
+    tiledMap.forEachLayer<TiledMapTileLayer> {
+      fail()
+    }
+  }
+
+  @Test
+  fun `should execute lambda when there is a layer for the given type`() {
+    var counter = 0
+
+    tiledMap.forEachLayer<MapLayer> {
+      it.isVisible = false
+      ++counter
+    }
+
+    assertEquals(2, counter)
+    assertTrue(tiledMap.layers.all { !it.isVisible })
   }
 }


### PR DESCRIPTION
Some small extensions that I introduced in my own project and that might be useful for others:
- `isEmpty` and `isNotEmpty` for `MapLayers` and `MapObjects` class
- `forEachLayer` for `TiledMap` class. The purpose of this function in my case was that I needed a way to iterate over a specific type of layers. LibGDX has a `getByType` function as part of `MapLayers` class. However, this function internally always creates an array and returns it as a result or you need to pass in an array that gets filled with those layers. 
I did not like that and that is the reason for the `forEachLayer` extension. It does basically the same but without the need of an additional array object.


Let me know if this is useful or not and in case it is useful if it requires changes or not ;)