### PR TITLE
(#485) make drawable and drawableName optional for scene2d image factory

### DIFF
--- a/scene2d/src/main/kotlin/ktx/scene2d/factory.kt
+++ b/scene2d/src/main/kotlin/ktx/scene2d/factory.kt
@@ -209,7 +209,7 @@ inline fun <S> KWidget<S>.horizontalGroup(
 }
 
 /**
- * @param drawableName optional name of a drawable stored in the chosen skin.
+ * @param drawableName name of a drawable stored in the chosen skin.
  * @param skin [Skin] instance that contains the widget style. Defaults to [Scene2DSkin.defaultSkin].
  * @param init will be invoked with the widget as "this". Consumes actor container (usually a [Cell] or [Node]) that
  * contains the widget. Might consume the actor itself if this group does not keep actors in dedicated containers.
@@ -219,16 +219,12 @@ inline fun <S> KWidget<S>.horizontalGroup(
 @Scene2dDsl
 @OptIn(ExperimentalContracts::class)
 inline fun <S> KWidget<S>.image(
-  drawableName: String? = null,
+  drawableName: String,
   skin: Skin = Scene2DSkin.defaultSkin,
   init: (@Scene2dDsl Image).(S) -> Unit = {},
 ): Image {
   contract { callsInPlace(init, InvocationKind.EXACTLY_ONCE) }
-  return if (drawableName == null) {
-    actor(Image(), init)
-  } else {
-    actor(Image(skin.getDrawable(drawableName)), init)
-  }
+  return actor(Image(skin.getDrawable(drawableName)), init)
 }
 
 /**

--- a/scene2d/src/main/kotlin/ktx/scene2d/factory.kt
+++ b/scene2d/src/main/kotlin/ktx/scene2d/factory.kt
@@ -209,7 +209,7 @@ inline fun <S> KWidget<S>.horizontalGroup(
 }
 
 /**
- * @param drawableName name of a drawable stored in the chosen skin.
+ * @param drawableName optional name of a drawable stored in the chosen skin.
  * @param skin [Skin] instance that contains the widget style. Defaults to [Scene2DSkin.defaultSkin].
  * @param init will be invoked with the widget as "this". Consumes actor container (usually a [Cell] or [Node]) that
  * contains the widget. Might consume the actor itself if this group does not keep actors in dedicated containers.
@@ -219,12 +219,16 @@ inline fun <S> KWidget<S>.horizontalGroup(
 @Scene2dDsl
 @OptIn(ExperimentalContracts::class)
 inline fun <S> KWidget<S>.image(
-  drawableName: String,
+  drawableName: String? = null,
   skin: Skin = Scene2DSkin.defaultSkin,
   init: (@Scene2dDsl Image).(S) -> Unit = {},
 ): Image {
   contract { callsInPlace(init, InvocationKind.EXACTLY_ONCE) }
-  return actor(Image(skin.getDrawable(drawableName)), init)
+  return if (drawableName == null) {
+    actor(Image(), init)
+  } else {
+    actor(Image(skin.getDrawable(drawableName)), init)
+  }
 }
 
 /**
@@ -279,7 +283,7 @@ inline fun <S> KWidget<S>.image(
 }
 
 /**
- * @param drawable will be drawn by the [Image].
+ * @param drawable will be drawn by the [Image]. Per default it is null.
  * @param init will be invoked with the widget as "this". Consumes actor container (usually a [Cell] or [Node]) that
  * contains the widget. Might consume the actor itself if this group does not keep actors in dedicated containers.
  * Inlined.
@@ -288,7 +292,7 @@ inline fun <S> KWidget<S>.image(
 @Scene2dDsl
 @OptIn(ExperimentalContracts::class)
 inline fun <S> KWidget<S>.image(
-  drawable: Drawable,
+  drawable: Drawable? = null,
   init: (@Scene2dDsl Image).(S) -> Unit = {},
 ): Image {
   contract { callsInPlace(init, InvocationKind.EXACTLY_ONCE) }

--- a/scene2d/src/test/kotlin/ktx/scene2d/factoryTest.kt
+++ b/scene2d/src/test/kotlin/ktx/scene2d/factoryTest.kt
@@ -6,7 +6,11 @@ import com.badlogic.gdx.scenes.scene2d.ui.Cell
 import com.badlogic.gdx.scenes.scene2d.ui.Label
 import com.badlogic.gdx.scenes.scene2d.ui.Tree.Node
 import com.kotcrab.vis.ui.VisUI
-import org.junit.Assert.*
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertSame
+import org.junit.Assert.assertTrue
 import org.junit.Test
 import org.mockito.kotlin.mock
 import com.badlogic.gdx.utils.Array as GdxArray
@@ -127,18 +131,6 @@ class NoInitBlockActorFactoriesTest : ApplicationTest() {
   )
 
   @Test
-  fun `should create Image with null drawable name`() = test(
-    widget = {
-      image(drawableName = null) {
-        color = Color.BLUE
-      }
-    },
-    validate = {
-      assertNull(it.drawable)
-    },
-  )
-
-  @Test
   fun `should create Image with nine patch`() = test { image(VisUI.getSkin().getPatch("button")) }
 
   @Test
@@ -156,8 +148,16 @@ class NoInitBlockActorFactoriesTest : ApplicationTest() {
   )
 
   @Test
-  fun `should create Image with null drawable`() = test(
+  fun `should create Image with null drawable passing null argument`() = test(
     widget = { image(drawable = null) },
+    validate = {
+      assertNull(it.drawable)
+    },
+  )
+
+  @Test
+  fun `should create Image with null drawable passing no arguments`() = test(
+    widget = { image() },
     validate = {
       assertNull(it.drawable)
     },

--- a/scene2d/src/test/kotlin/ktx/scene2d/factoryTest.kt
+++ b/scene2d/src/test/kotlin/ktx/scene2d/factoryTest.kt
@@ -6,10 +6,7 @@ import com.badlogic.gdx.scenes.scene2d.ui.Cell
 import com.badlogic.gdx.scenes.scene2d.ui.Label
 import com.badlogic.gdx.scenes.scene2d.ui.Tree.Node
 import com.kotcrab.vis.ui.VisUI
-import org.junit.Assert
-import org.junit.Assert.assertEquals
-import org.junit.Assert.assertNotNull
-import org.junit.Assert.assertTrue
+import org.junit.Assert.*
 import org.junit.Test
 import org.mockito.kotlin.mock
 import com.badlogic.gdx.utils.Array as GdxArray
@@ -130,6 +127,18 @@ class NoInitBlockActorFactoriesTest : ApplicationTest() {
   )
 
   @Test
+  fun `should create Image with null drawable name`() = test(
+    widget = {
+      image(drawableName = null) {
+        color = Color.BLUE
+      }
+    },
+    validate = {
+      assertNull(it.drawable)
+    },
+  )
+
+  @Test
   fun `should create Image with nine patch`() = test { image(VisUI.getSkin().getPatch("button")) }
 
   @Test
@@ -142,7 +151,15 @@ class NoInitBlockActorFactoriesTest : ApplicationTest() {
   fun `should create Image with drawable`() = test(
     widget = { image(VisUI.getSkin().getDrawable("button")) },
     validate = {
-      Assert.assertSame(VisUI.getSkin().getDrawable("button"), it.drawable)
+      assertSame(VisUI.getSkin().getDrawable("button"), it.drawable)
+    },
+  )
+
+  @Test
+  fun `should create Image with null drawable`() = test(
+    widget = { image(drawable = null) },
+    validate = {
+      assertNull(it.drawable)
     },
   )
 


### PR DESCRIPTION
PR for #485.

I did not adjust the factory methods for Texture, TextureRegion and NinePatch because I think they will throw an exception, but more importantly, I think in those cases it does not make sense. Drawable and drawable name do make sense because in a Skin, from what I know, you can reference Drawables and in the case of an image they are optional.

