### PR TITLE
Update sample workflow to Java 17

### DIFF
--- a/.github/workflows/publish-project-samples.yml
+++ b/.github/workflows/publish-project-samples.yml
@@ -16,7 +16,7 @@ jobs:
       - name: JDK setup
         uses: actions/setup-java@v3
         with:
-          java-version: 11
+          java-version: 17
           distribution: temurin
       - name: Save versions
         shell: bash


### PR DESCRIPTION
`gdx-liftoff` now seems to require JDK 17, which prevents the automated sample publishing pipeline from working correctly.

See #489.