### PR TITLE
Add composable Scene2D DSL factory prototype

### DIFF
--- a/docs/superpowers/plans/2026-08-29-scene2d-composable-dsl-prototype.md
+++ b/docs/superpowers/plans/2026-08-29-scene2d-composable-dsl-prototype.md
@@ -1,0 +1,391 @@
+# Composable Scene2D DSL Prototype Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add separated actor placement/init and reusable `Scene2dFactoryDescriptor` recipes to the `scene2d` module without compiler tooling.
+
+**Architecture:** Keep `KWidget<out Storage>` as the parent capability. Add `mount` as the shared store → placement → init primitive, and let `Scene2dFactoryDescriptor<A>` hold a `RootWidget` recipe that is rebuilt on every invocation. Convert only `table` to the separated callback shape in this prototype; leave other built-in factories unchanged.
+
+**Tech Stack:** Kotlin 2.1.10, libGDX 1.13.1, Gradle Kotlin DSL, JUnit 4, Mockito-Kotlin, Ktlint.
+
+**Spec:** `docs/superpowers/specs/2026-08-29-scene2d-composable-dsl-prototype-design.md`
+
+## Global Constraints
+
+- Preserve `Scene2DSkin.defaultSkin` behavior.
+- Avoid reflection, KSP, compiler plugins, generated adapters, and registration.
+- Create fresh actors for every `Scene2dFactoryDescriptor` invocation.
+- Use `storeActor(actor)`, then placement, then actor init.
+- Keep non-table built-in factory signatures unchanged.
+- Do not add two-typed factory scopes or parent-aware construction.
+- Do not add a metadata annotation; avoid classifier-name collision and keep descriptor API minimal.
+- Do not introduce source-compatible legacy/new `table` overloads; trailing-lambda ambiguity is deferred.
+- Follow existing formatting and test conventions in `scene2d`.
+
+---
+
+### Task 1: Add failing factory composition tests
+
+**Files:**
+- Create: `scene2d/src/test/kotlin/ktx/scene2d/Scene2dFactoryTest.kt`
+
+**Interfaces:**
+- Consumes: planned `scene2dFactory`, `Scene2dFactoryDescriptor.invoke`, separated `table`, and `mount` APIs.
+- Produces: executable acceptance coverage for core implementation tasks.
+
+- [ ] **Step 1: Write failing tests for factory values and separated callbacks**
+
+Create `Scene2dFactoryTest : ApplicationTest` with these tests:
+
+```kotlin
+private val sidePane = scene2dFactory {
+  table {
+    label("Inventory")
+  }
+}
+
+@Test
+fun `factory value can be invoked in root scope and creates fresh actors`() {
+  val first = scene2d { sidePane() }
+  val second = scene2d { sidePane() }
+
+  assertNotSame(first, second)
+  assertEquals("Inventory", (first.children.first() as Label).text.toString())
+  assertEquals("Inventory", (second.children.first() as Label).text.toString())
+}
+
+@Test
+fun `factory trailing init configures actor and placement configures table cell`() {
+  val root = scene2d.table {
+    sidePane(
+      placement = {
+        growY()
+      },
+    ) {
+      label("Extra content")
+    }
+  }
+
+  val pane = root.children.first() as KTableWidget
+  assertEquals(2, pane.children.size)
+  assertEquals("Extra content", (pane.children[1] as Label).text.toString())
+  assertTrue(root.getCell(pane).expandY)
+}
+
+@Test
+fun `same factory mounts in table and group scopes`() {
+  val table = scene2d.table { sidePane() }
+  val group = scene2d.stack { sidePane() }
+
+  assertSame(table, (table.children.first() as KTableWidget).parent)
+  assertSame(group, group.children.first().parent)
+}
+```
+
+Add a custom actor proving `mount` delegates construction, placement, and init:
+
+```kotlin
+private class HealthBar(val value: Float) : Actor()
+
+private inline fun <S> KWidget<S>.healthBar(
+  value: Float,
+  placement: S.() -> Unit = {},
+  init: HealthBar.() -> Unit = {},
+): HealthBar = mount(HealthBar(value), placement, init)
+
+@Test
+fun `custom actor factory uses mount`() {
+  val root = scene2d.stack {
+    healthBar(0.75f) {
+      name = "health"
+    }
+  }
+
+  assertEquals("health", root.children.first().name)
+  assertEquals(0.75f, (root.children.first() as HealthBar).value, TOLERANCE)
+}
+```
+
+Use imports already established by `factoryTest.kt`: `Actor`, `Label`, `assertEquals`, `assertNotSame`, `assertSame`, `assertTrue`, and `org.junit.Test`.
+
+- [ ] **Step 2: Run tests and verify expected compile failure**
+
+Run:
+
+```bash
+./gradlew :scene2d:test --tests ktx.scene2d.Scene2dFactoryTest
+```
+
+Expected: compilation fails because `scene2dFactory`, `Scene2dFactoryDescriptor`, `mount`, and separated `table` do not exist yet.
+
+- [ ] **Step 3: Commit failing tests**
+
+```bash
+git add scene2d/src/test/kotlin/ktx/scene2d/Scene2dFactoryTest.kt
+git commit -m "test: specify composable Scene2D factory behavior"
+```
+
+---
+
+### Task 2: Implement factory kernel
+
+**Files:**
+- Modify: `scene2d/src/main/kotlin/ktx/scene2d/widget.kt`
+- Modify: `scene2d/src/main/kotlin/ktx/scene2d/factory.kt`
+
+**Interfaces:**
+- Consumes: failing tests from Task 1 and existing `KWidget`, `RootWidget`, and `scene2d` APIs.
+- Produces: `Scene2dFactoryDescriptor<A>`, `scene2dFactory`, `mount`, and factory-value invocation.
+
+- [ ] **Step 1: Add recipe descriptor and constructor function**
+
+In `factory.kt`, add imports for `kotlin.contracts.ExperimentalContracts`, `InvocationKind`, and contract helpers if needed by the implementation. Define:
+
+```kotlin
+@Scene2dDsl
+class Scene2dFactoryDescriptor<A : Actor> internal constructor(
+  internal val build: RootWidget.() -> A,
+)
+
+fun <A : Actor> scene2dFactory(
+  build: RootWidget.() -> A,
+): Scene2dFactoryDescriptor<A> = Scene2dFactoryDescriptor(build)
+```
+
+The descriptor must contain only the recipe. It must not construct or cache an actor during descriptor creation.
+
+- [ ] **Step 2: Add `mount` with exact operation order**
+
+In `factory.kt`, add:
+
+```kotlin
+@Scene2dDsl
+inline fun <S, A : Actor> KWidget<S>.mount(
+  actor: A,
+  placement: S.() -> Unit = {},
+  init: A.() -> Unit = {},
+): A {
+  val stored = storeActor(actor)
+  stored.placement()
+  actor.init()
+  return actor
+}
+```
+
+Add an exact-once contract for both lambdas only if Kotlin accepts it without changing existing module conventions. Do not add rollback or actor reuse handling.
+
+- [ ] **Step 3: Add member-extension factory invocation**
+
+Inside `KWidget<out Storage>` in `widget.kt`, add:
+
+```kotlin
+@Scene2dDsl
+operator fun <A : Actor> Scene2dFactoryDescriptor<A>.invoke(
+  placement: @UnsafeVariance Storage.() -> Unit = {},
+  init: A.() -> Unit = {},
+): A {
+  return mount(scene2d(build), placement, init)
+}
+```
+
+The factory recipe must execute through `scene2d(build)`, so nested built-ins use `RootWidget` and each call creates a new actor tree. Keep `@UnsafeVariance` limited to the placement receiver.
+
+- [ ] **Step 4: Run focused tests and resolve only kernel compile errors**
+
+Run:
+
+```bash
+./gradlew :scene2d:test --tests ktx.scene2d.Scene2dFactoryTest
+```
+
+Expected: tests compile and pass except for failures caused by the not-yet-migrated `table` signature. Fix type/signature errors in the new kernel only; do not convert other factories.
+
+- [ ] **Step 5: Commit kernel implementation**
+
+```bash
+git add scene2d/src/main/kotlin/ktx/scene2d/widget.kt scene2d/src/main/kotlin/ktx/scene2d/factory.kt
+git commit -m "feat: add composable Scene2D factory kernel"
+```
+
+---
+
+### Task 3: Convert table to separated placement and init
+
+**Files:**
+- Modify: `scene2d/src/main/kotlin/ktx/scene2d/factory.kt`
+- Modify: `scene2d/src/test/kotlin/ktx/scene2d/factoryTest.kt`
+- Modify: `scene2d/src/test/kotlin/ktx/scene2d/StageWidgetTest.kt` if table callback parameters are used there
+
+**Interfaces:**
+- Consumes: `mount` from Task 2.
+- Produces: `KWidget<S>.table(skin, placement, init)` returning `KTableWidget`.
+
+- [ ] **Step 1: Change `table` to separated callbacks**
+
+Replace the existing table factory with:
+
+```kotlin
+@Scene2dDsl
+@OptIn(ExperimentalContracts::class)
+inline fun <S> KWidget<S>.table(
+  skin: Skin = Scene2DSkin.defaultSkin,
+  placement: S.() -> Unit = {},
+  init: KTableWidget.() -> Unit = {},
+): KTableWidget {
+  contract { callsInPlace(init, InvocationKind.EXACTLY_ONCE) }
+  return mount(
+    actor = KTableWidget(skin),
+    placement = placement,
+    init = init,
+  )
+}
+```
+
+Keep `skin` first so existing `table()` and `table(skin = customSkin)` calls remain natural. Do not add a second legacy overload.
+
+- [ ] **Step 2: Update tests that explicitly consume table storage**
+
+Search:
+
+```bash
+rg -n "table\s*\{|table\(" scene2d/src/test/kotlin/ktx/scene2d
+```
+
+Change table trailing lambdas from `KTableWidget.(S) -> Unit` form to actor receiver form. Move cell assertions into `placement = { ... }` or use `inCell` from the created actor. Preserve all existing behavior assertions.
+
+- [ ] **Step 3: Run focused and existing factory tests**
+
+Run:
+
+```bash
+./gradlew :scene2d:test --tests ktx.scene2d.Scene2dFactoryTest --tests ktx.scene2d.RootActorFactoriesTest --tests ktx.scene2d.NoInitBlockActorFactoriesTest --tests ktx.scene2d.InlinedInitBlockActorFactoriesTest
+```
+
+Expected: PASS. Existing non-table callback tests must remain unchanged and green.
+
+- [ ] **Step 4: Commit table migration**
+
+```bash
+git add scene2d/src/main/kotlin/ktx/scene2d/factory.kt scene2d/src/test/kotlin/ktx/scene2d/factoryTest.kt scene2d/src/test/kotlin/ktx/scene2d/StageWidgetTest.kt
+git commit -m "feat: separate Scene2D table placement from init"
+```
+
+---
+
+### Task 4: Document supported composition patterns
+
+**Files:**
+- Modify: `scene2d/README.md`
+
+**Interfaces:**
+- Consumes: public APIs delivered by Tasks 2–3.
+- Produces: user-facing documentation for the prototype boundary.
+
+- [ ] **Step 1: Add factory-value section after existing builder customization guidance**
+
+Document that `scene2dFactory` stores a recipe and creates fresh actors per invocation. Include this exact pattern:
+
+```kotlin
+private val sidePane = scene2dFactory {
+  table {
+    label("Inventory")
+  }
+}
+
+val root = scene2d.table {
+  sidePane(placement = { growY() }) {
+    label("Extra content")
+  }
+}
+```
+
+Explain that the trailing lambda configures the created actor while `placement` configures the parent storage object.
+
+- [ ] **Step 2: Add custom and parameterized factory guidance**
+
+Include this custom actor extension:
+
+```kotlin
+inline fun <S> KWidget<S>.healthBar(
+  value: Float,
+  placement: S.() -> Unit = {},
+  init: HealthBar.() -> Unit = {},
+): HealthBar = mount(HealthBar(value), placement, init)
+```
+
+Explain that parameterized or parent-aware components remain ordinary `KWidget` extension functions. State that factories do not cache actors.
+
+- [ ] **Step 3: Add prototype limitations**
+
+State that only `table` uses separated callbacks in this first prototype, other built-ins retain existing callback forms, and compiler plugins/KSP/reflection are not required. Do not document nonexistent compatibility overloads.
+
+- [ ] **Step 4: Run documentation-aware formatting/checks**
+
+Run:
+
+```bash
+./gradlew :scene2d:check
+```
+
+Expected: PASS, including Kotlin formatting and documentation checks configured by the repository.
+
+- [ ] **Step 5: Commit documentation**
+
+```bash
+git add scene2d/README.md
+git commit -m "docs: explain composable Scene2D factories"
+```
+
+---
+
+### Task 5: Full verification and review handoff
+
+**Files:**
+- Review all files changed by Tasks 1–4.
+
+**Interfaces:**
+- Consumes: complete prototype implementation and test/doc commits.
+- Produces: verified branch with residual-risk report.
+
+- [ ] **Step 1: Run full module tests**
+
+Run:
+
+```bash
+./gradlew :scene2d:test
+```
+
+Expected: PASS for all Scene2D tests.
+
+- [ ] **Step 2: Run full module checks**
+
+Run:
+
+```bash
+./gradlew :scene2d:check
+```
+
+Expected: PASS with no formatting or API validation failures.
+
+- [ ] **Step 3: Inspect diff and status**
+
+Run:
+
+```bash
+git diff master...HEAD --check
+git diff master...HEAD --stat
+git status --short --branch
+```
+
+Expected: only approved spec, plan, Scene2D implementation/tests/docs are tracked; generated `.pi/` remains untracked and is not staged.
+
+- [ ] **Step 4: Commit any narrowly scoped verification fixes**
+
+If checks expose a real implementation defect, fix it with a regression test first, rerun the affected command, then commit the approved prototype files:
+
+```bash
+git add scene2d/src/main/kotlin/ktx/scene2d/widget.kt scene2d/src/main/kotlin/ktx/scene2d/factory.kt scene2d/src/test/kotlin/ktx/scene2d/Scene2dFactoryTest.kt scene2d/README.md
+git commit -m "fix: address Scene2D prototype verification finding"
+```
+
+Do not broaden scope into full factory migration.

--- a/docs/superpowers/plans/2026-08-29-scene2d-composable-dsl-prototype.md
+++ b/docs/superpowers/plans/2026-08-29-scene2d-composable-dsl-prototype.md
@@ -90,7 +90,7 @@ private class HealthBar(val value: Float) : Actor()
 private inline fun <S> KWidget<S>.healthBar(
   value: Float,
   placement: S.() -> Unit = {},
-  init: HealthBar.() -> Unit = {},
+  init: (@Scene2dDsl HealthBar).() -> Unit = {},
 ): HealthBar = mount(HealthBar(value), placement, init)
 
 @Test
@@ -163,7 +163,7 @@ In `factory.kt`, add:
 inline fun <S, A : Actor> KWidget<S>.mount(
   actor: A,
   placement: S.() -> Unit = {},
-  init: A.() -> Unit = {},
+  init: (@Scene2dDsl A).() -> Unit = {},
 ): A {
   val stored = storeActor(actor)
   stored.placement()
@@ -182,7 +182,7 @@ Inside `KWidget<out Storage>` in `widget.kt`, add:
 @Scene2dDsl
 operator fun <A : Actor> Scene2dFactoryDescriptor<A>.invoke(
   placement: @UnsafeVariance Storage.() -> Unit = {},
-  init: A.() -> Unit = {},
+  init: (@Scene2dDsl A).() -> Unit = {},
 ): A {
   return mount(scene2d(build), placement, init)
 }
@@ -309,7 +309,7 @@ Include this custom actor extension:
 inline fun <S> KWidget<S>.healthBar(
   value: Float,
   placement: S.() -> Unit = {},
-  init: HealthBar.() -> Unit = {},
+  init: (@Scene2dDsl HealthBar).() -> Unit = {},
 ): HealthBar = mount(HealthBar(value), placement, init)
 ```
 

--- a/docs/superpowers/specs/2026-08-29-scene2d-composable-dsl-prototype-design.md
+++ b/docs/superpowers/specs/2026-08-29-scene2d-composable-dsl-prototype-design.md
@@ -1,0 +1,192 @@
+# Composable Scene2D DSL Prototype
+
+## Status
+
+Approved prototype design. This document covers the first implementation experiment from
+`ktx_scene2d_composable_dsl_design.docx`; it does not implement the full factory migration.
+
+## Goal
+
+Make reusable actor recipes compose through the same public kernel as built-in Scene2D DSL
+constructs, while separating actor initialization from parent-specific placement.
+
+The prototype must preserve `Scene2DSkin.defaultSkin`, avoid reflection/KSP/compiler plugins,
+and leave non-table built-in factory APIs unchanged.
+
+## Scope
+
+### In scope
+
+- Add `mount(actor, placement, init)` as the separated builder primitive.
+- Add `Scene2dFactory<A : Actor>` and `scene2dFactory` for reusable actor recipes.
+- Add a member-extension `invoke` operator so factory values are callable inside any `KWidget`
+  scope.
+- Convert `table` to separated `placement` and actor `init` callbacks.
+- Add focused runtime and compile-time coverage for root, table, group, nested, and custom
+  factories.
+- Document factory values, placement, parameterized extension factories, and semantic fragments.
+
+### Out of scope
+
+- Converting every built-in factory to `mount`.
+- Source-compatible legacy/new overloads for `table`; those overloads risk ambiguous calls with
+  trailing lambdas and are deferred to the broader migration.
+- Removing `Scene2DSkin.defaultSkin`.
+- Two-typed factories with a separate actor scope.
+- Reflection, KSP, compiler plugins, registration, or generated adapters.
+- Parent-aware construction for factories that need parent information.
+
+## API design
+
+### Mounting
+
+```kotlin
+inline fun <S, A : Actor> KWidget<S>.mount(
+  actor: A,
+  placement: S.() -> Unit = {},
+  init: A.() -> Unit = {},
+): A
+```
+
+`mount` stores the actor, applies placement to the returned storage, applies actor
+initialization, and returns the actor. Storage remains parent-specific: `Cell` for tables,
+`KNode` for trees, and `Actor` for groups/root.
+
+The operation order is:
+
+1. `storeActor(actor)`
+2. `stored.placement()`
+3. `actor.init()`
+4. return `actor`
+
+Exceptions propagate without rollback, matching current builder behavior and libGDX ownership
+semantics.
+
+### Factory descriptors
+
+```kotlin
+@Scene2dDsl
+class Scene2dFactory<A : Actor> internal constructor(
+  internal val build: RootWidget.() -> A,
+)
+
+inline fun <A : Actor> scene2dFactory(
+  noinline build: RootWidget.() -> A,
+): Scene2dFactory<A>
+```
+
+A factory stores a recipe, not an actor. Each invocation executes the recipe through `scene2d`
+and therefore creates a fresh actor tree.
+
+`KWidget` exposes:
+
+```kotlin
+operator fun <A : Actor> Scene2dFactory<A>.invoke(
+  placement: @UnsafeVariance Storage.() -> Unit = {},
+  init: A.() -> Unit = {},
+): A
+```
+
+The operator builds the detached root, then uses `mount` to store and configure it. The
+`@UnsafeVariance` annotation is limited to the placement receiver required by covariant
+`KWidget<out Storage>`.
+
+### Metadata annotation
+
+```kotlin
+@Target(AnnotationTarget.PROPERTY, AnnotationTarget.FUNCTION)
+@Retention(AnnotationRetention.BINARY)
+annotation class Scene2dFactory
+```
+
+The annotation is optional metadata for documentation, future static analysis, and possible
+future tooling. Runtime behavior must not depend on it.
+
+### Table factory
+
+`table` receives separated callbacks:
+
+```kotlin
+inline fun <S> KWidget<S>.table(
+  skin: Skin = Scene2DSkin.defaultSkin,
+  placement: S.() -> Unit = {},
+  init: KTableWidget.() -> Unit = {},
+): KTableWidget
+```
+
+Placement configures the parent-created storage object. The trailing lambda configures the
+created `KTableWidget` and can create nested children. Other built-in factories continue using
+current callback shapes during this prototype.
+
+## Data flow examples
+
+Private reusable component:
+
+```kotlin
+@Scene2dFactory
+private val sidePane = scene2dFactory {
+  table {
+    label("Inventory")
+  }
+}
+
+scene2d.table {
+  sidePane(placement = { growY() }) {
+    label("Extra content")
+  }
+}
+```
+
+Custom actor factory:
+
+```kotlin
+inline fun <S> KWidget<S>.healthBar(
+  value: Float,
+  placement: S.() -> Unit = {},
+  init: HealthBar.() -> Unit = {},
+): HealthBar = mount(HealthBar(value), placement, init)
+```
+
+Parameterized components remain ordinary private or public `KWidget` extension functions.
+Semantic fragments remain ordinary scoped functions and do not require an `Actor` subclass.
+
+## Files
+
+- `scene2d/src/main/kotlin/ktx/scene2d/Scene2dDsl.kt`: metadata annotation.
+- `scene2d/src/main/kotlin/ktx/scene2d/widget.kt`: `KWidget` factory invocation operator.
+- `scene2d/src/main/kotlin/ktx/scene2d/factory.kt`: `mount`, factory descriptor creation, and
+  separated `table` implementation.
+- `scene2d/src/test/kotlin/ktx/scene2d/Scene2dFactoryTest.kt`: focused factory and placement
+  behavior tests.
+- `scene2d/README.md`: usage and extension guidance.
+
+## Verification
+
+Run:
+
+```text
+./gradlew :scene2d:test
+./gradlew :scene2d:check
+```
+
+Tests must verify:
+
+- Factory values invoke in root, table, and group scopes.
+- Factory invocation creates fresh actors on repeated calls.
+- Trailing init receives the created actor and can append children.
+- Placement configures parent storage without exposing storage in actor init.
+- One factory mounts under table and group without changing its definition.
+- Nested factories compose.
+- Custom actor factories delegate to `mount`.
+- Default skin behavior remains unchanged.
+- Existing non-table factory coverage remains green.
+
+Formatting follows existing repository Gradle/Ktlint checks.
+
+## Migration boundary
+
+This prototype answers whether factory values plus a member-extension `invoke` provide natural
+DSL composition without hidden tooling. If successful, later work can convert other built-ins
+to `mount`, add staged compatibility bridges, and expand documentation. Those changes require a
+separate migration design because overload ambiguity and binary/source compatibility need their
+own treatment.

--- a/docs/superpowers/specs/2026-08-29-scene2d-composable-dsl-prototype-design.md
+++ b/docs/superpowers/specs/2026-08-29-scene2d-composable-dsl-prototype-design.md
@@ -46,7 +46,7 @@ and leave non-table built-in factory APIs unchanged.
 inline fun <S, A : Actor> KWidget<S>.mount(
   actor: A,
   placement: S.() -> Unit = {},
-  init: A.() -> Unit = {},
+  init: (@Scene2dDsl A).() -> Unit = {},
 ): A
 ```
 
@@ -85,7 +85,7 @@ and therefore creates a fresh actor tree.
 ```kotlin
 operator fun <A : Actor> Scene2dFactoryDescriptor<A>.invoke(
   placement: @UnsafeVariance Storage.() -> Unit = {},
-  init: A.() -> Unit = {},
+  init: (@Scene2dDsl A).() -> Unit = {},
 ): A
 ```
 
@@ -133,7 +133,7 @@ Custom actor factory:
 inline fun <S> KWidget<S>.healthBar(
   value: Float,
   placement: S.() -> Unit = {},
-  init: HealthBar.() -> Unit = {},
+  init: (@Scene2dDsl HealthBar).() -> Unit = {},
 ): HealthBar = mount(HealthBar(value), placement, init)
 ```
 

--- a/docs/superpowers/specs/2026-08-29-scene2d-composable-dsl-prototype-design.md
+++ b/docs/superpowers/specs/2026-08-29-scene2d-composable-dsl-prototype-design.md
@@ -18,7 +18,7 @@ and leave non-table built-in factory APIs unchanged.
 ### In scope
 
 - Add `mount(actor, placement, init)` as the separated builder primitive.
-- Add `Scene2dFactory<A : Actor>` and `scene2dFactory` for reusable actor recipes.
+- Add `Scene2dFactoryDescriptor<A : Actor>` and `scene2dFactory` for reusable actor recipes.
 - Add a member-extension `invoke` operator so factory values are callable inside any `KWidget`
   scope.
 - Convert `table` to separated `placement` and actor `init` callbacks.
@@ -31,6 +31,8 @@ and leave non-table built-in factory APIs unchanged.
 - Converting every built-in factory to `mount`.
 - Source-compatible legacy/new overloads for `table`; those overloads risk ambiguous calls with
   trailing lambdas and are deferred to the broader migration.
+- Factory metadata annotation; the prototype keeps descriptor API minimal and avoids optional
+  tooling.
 - Removing `Scene2DSkin.defaultSkin`.
 - Two-typed factories with a separate actor scope.
 - Reflection, KSP, compiler plugins, registration, or generated adapters.
@@ -66,13 +68,13 @@ semantics.
 
 ```kotlin
 @Scene2dDsl
-class Scene2dFactory<A : Actor> internal constructor(
+class Scene2dFactoryDescriptor<A : Actor> internal constructor(
   internal val build: RootWidget.() -> A,
 )
 
-inline fun <A : Actor> scene2dFactory(
-  noinline build: RootWidget.() -> A,
-): Scene2dFactory<A>
+fun <A : Actor> scene2dFactory(
+  build: RootWidget.() -> A,
+): Scene2dFactoryDescriptor<A>
 ```
 
 A factory stores a recipe, not an actor. Each invocation executes the recipe through `scene2d`
@@ -81,7 +83,7 @@ and therefore creates a fresh actor tree.
 `KWidget` exposes:
 
 ```kotlin
-operator fun <A : Actor> Scene2dFactory<A>.invoke(
+operator fun <A : Actor> Scene2dFactoryDescriptor<A>.invoke(
   placement: @UnsafeVariance Storage.() -> Unit = {},
   init: A.() -> Unit = {},
 ): A
@@ -90,17 +92,6 @@ operator fun <A : Actor> Scene2dFactory<A>.invoke(
 The operator builds the detached root, then uses `mount` to store and configure it. The
 `@UnsafeVariance` annotation is limited to the placement receiver required by covariant
 `KWidget<out Storage>`.
-
-### Metadata annotation
-
-```kotlin
-@Target(AnnotationTarget.PROPERTY, AnnotationTarget.FUNCTION)
-@Retention(AnnotationRetention.BINARY)
-annotation class Scene2dFactory
-```
-
-The annotation is optional metadata for documentation, future static analysis, and possible
-future tooling. Runtime behavior must not depend on it.
 
 ### Table factory
 
@@ -123,7 +114,6 @@ current callback shapes during this prototype.
 Private reusable component:
 
 ```kotlin
-@Scene2dFactory
 private val sidePane = scene2dFactory {
   table {
     label("Inventory")
@@ -152,7 +142,6 @@ Semantic fragments remain ordinary scoped functions and do not require an `Actor
 
 ## Files
 
-- `scene2d/src/main/kotlin/ktx/scene2d/Scene2dDsl.kt`: metadata annotation.
 - `scene2d/src/main/kotlin/ktx/scene2d/widget.kt`: `KWidget` factory invocation operator.
 - `scene2d/src/main/kotlin/ktx/scene2d/factory.kt`: `mount`, factory descriptor creation, and
   separated `table` implementation.

--- a/scene2d/README.md
+++ b/scene2d/README.md
@@ -209,12 +209,14 @@ providing some syntax sugar. Keep in mind that Scene2D was written in Java, so w
 (`color = Color.RED`), most are not (`setWrap(true)`). This is because we wanted to create a thin wrapper over Scene2D,
 and we opted against duplicating its entire API. It is still pretty straightforward to configure most actors.
 
-All building blocks are inlined during compilation, which means there is little to no runtime overhead when using
-`ktx-scene2d`. This code will be pretty much as fast as your good old Java, while remaining cleaner and safer.
+Built-in actor factory building blocks are inlined during compilation, which means there is little to no runtime
+overhead when using `ktx-scene2d`. This code will be pretty much as fast as your good old Java, while remaining cleaner
+and safer.
 
 ### Composable Scene2D factories
 
-`scene2dFactory` stores a recipe and creates fresh actors on every invocation. That lets private, reusable DSL fragments
+`scene2dFactory` stores a recipe and creates fresh actors on every invocation. Descriptor construction is intentionally
+not inlined; invoking the resulting recipe still composes through the same DSL. That lets private, reusable DSL fragments
 behave like built-in widgets without extra registry or tooling.
 
 ```kotlin
@@ -241,7 +243,7 @@ function. For example:
 inline fun <S> KWidget<S>.healthBar(
   value: Float,
   placement: S.() -> Unit = {},
-  init: HealthBar.() -> Unit = {},
+  init: (@Scene2dDsl HealthBar).() -> Unit = {},
 ): HealthBar = mount(HealthBar(value), placement, init)
 ```
 

--- a/scene2d/README.md
+++ b/scene2d/README.md
@@ -212,6 +212,44 @@ and we opted against duplicating its entire API. It is still pretty straightforw
 All building blocks are inlined during compilation, which means there is little to no runtime overhead when using
 `ktx-scene2d`. This code will be pretty much as fast as your good old Java, while remaining cleaner and safer.
 
+### Composable Scene2D factories
+
+`scene2dFactory` stores a recipe and creates fresh actors on every invocation. That lets private, reusable DSL fragments
+behave like built-in widgets without extra registry or tooling.
+
+```kotlin
+private val sidePane = scene2dFactory {
+  table {
+    label("Inventory")
+  }
+}
+
+val root = scene2d.table {
+  sidePane(placement = { growY() }) {
+    label("Extra content")
+  }
+}
+```
+
+The trailing lambda configures the created actor. `placement` configures the parent storage object, such as a `Cell`
+from `table`.
+
+When a reusable component needs parameters or depends on current parent, keep it as an ordinary `KWidget` extension
+function. For example:
+
+```kotlin
+inline fun <S> KWidget<S>.healthBar(
+  value: Float,
+  placement: S.() -> Unit = {},
+  init: HealthBar.() -> Unit = {},
+): HealthBar = mount(HealthBar(value), placement, init)
+```
+
+Factories do not cache actors. Each call builds a fresh actor tree, then mounts it into current parent.
+
+Only `table` uses separated placement/init callbacks in this prototype. Other built-ins keep existing callback forms,
+and compiler plugins, KSP, or reflection are not required.
+
 Note that the `scene2d.` prefix is only necessary for top-level actors to start using the DSL. In effect, it's only
 necessary if you'd like to assign the widget to a variable and add it to a `Stage` or another widget group later on.
 When inside a DSL block, `scene2d.` prefix is not only no longer necessary to define actors, but it will actually

--- a/scene2d/src/main/kotlin/ktx/scene2d/factory.kt
+++ b/scene2d/src/main/kotlin/ktx/scene2d/factory.kt
@@ -40,6 +40,48 @@ import kotlin.contracts.contract
 import com.badlogic.gdx.utils.Array as GdxArray
 
 /**
+ * Recipe for creating fresh Scene2D actor trees in any [KWidget] scope.
+ * @param build creates the root actor using [RootWidget] DSL.
+ */
+@Scene2dDsl
+class Scene2dFactoryDescriptor<A : Actor> internal constructor(
+  internal val build: RootWidget.() -> A,
+)
+
+/**
+ * Creates a reusable Scene2D actor recipe.
+ * @param build creates the root actor using [RootWidget] DSL. Invoked every time the factory is mounted.
+ * @return descriptor that can be called inside any [KWidget] scope.
+ */
+@Scene2dDsl
+fun <A : Actor> scene2dFactory(build: RootWidget.() -> A): Scene2dFactoryDescriptor<A> =
+  Scene2dFactoryDescriptor(build)
+
+/**
+ * Adds [actor] to this widget, configures the parent-specific storage, then initializes the actor.
+ * @param actor will be added to this widget.
+ * @param placement configures the storage object returned by [KWidget.storeActor].
+ * @param init configures [actor] after it is stored.
+ * @return the passed [actor].
+ */
+@Scene2dDsl
+@OptIn(ExperimentalContracts::class)
+inline fun <S, A : Actor> KWidget<S>.mount(
+  actor: A,
+  placement: S.() -> Unit = {},
+  init: A.() -> Unit = {},
+): A {
+  contract {
+    callsInPlace(placement, InvocationKind.EXACTLY_ONCE)
+    callsInPlace(init, InvocationKind.EXACTLY_ONCE)
+  }
+  val stored = storeActor(actor)
+  stored.placement()
+  actor.init()
+  return actor
+}
+
+/**
  * Constructs a top-level [Window] widget.
  * @param title will be displayed as window's title.
  * @param style name of the widget style. Defaults to [defaultStyle].

--- a/scene2d/src/main/kotlin/ktx/scene2d/factory.kt
+++ b/scene2d/src/main/kotlin/ktx/scene2d/factory.kt
@@ -620,19 +620,23 @@ inline fun <S> KWidget<S>.stack(init: KStack.(S) -> Unit = {}): KStack {
 
 /**
  * @param skin [Skin] instance that will be applied to some table children. Defaults to [Scene2DSkin.defaultSkin].
- * @param init will be invoked with the widget as "this". Consumes actor container (usually a [Cell] or [Node]) that
- * contains the widget. Might consume the actor itself if this group does not keep actors in dedicated containers.
- * Inlined.
+ * @param placement configures the parent-specific storage object that contains this table.
+ * @param init will be invoked with the widget as "this". Inlined.
  * @return a [Table] instance added to this group.
  */
 @Scene2dDsl
 @OptIn(ExperimentalContracts::class)
 inline fun <S> KWidget<S>.table(
   skin: Skin = Scene2DSkin.defaultSkin,
-  init: KTableWidget.(S) -> Unit = {},
+  placement: S.() -> Unit = {},
+  init: KTableWidget.() -> Unit = {},
 ): KTableWidget {
   contract { callsInPlace(init, InvocationKind.EXACTLY_ONCE) }
-  return actor(KTableWidget(skin), init)
+  return mount(
+    actor = KTableWidget(skin),
+    placement = placement,
+    init = init,
+  )
 }
 
 /**

--- a/scene2d/src/main/kotlin/ktx/scene2d/factory.kt
+++ b/scene2d/src/main/kotlin/ktx/scene2d/factory.kt
@@ -69,7 +69,7 @@ fun <A : Actor> scene2dFactory(build: RootWidget.() -> A): Scene2dFactoryDescrip
 inline fun <S, A : Actor> KWidget<S>.mount(
   actor: A,
   placement: S.() -> Unit = {},
-  init: A.() -> Unit = {},
+  init: (@Scene2dDsl A).() -> Unit = {},
 ): A {
   contract {
     callsInPlace(placement, InvocationKind.EXACTLY_ONCE)

--- a/scene2d/src/main/kotlin/ktx/scene2d/widget.kt
+++ b/scene2d/src/main/kotlin/ktx/scene2d/widget.kt
@@ -45,6 +45,18 @@ interface KWidget<out Storage> {
    * @see Cell
    */
   fun <T : Actor> storeActor(actor: T): Storage
+
+  /**
+   * Creates and stores a fresh actor tree from the factory descriptor.
+   * @param placement configures the storage object returned by [storeActor].
+   * @param init configures the actor created by the factory.
+   * @return actor created by the factory.
+   */
+  @Scene2dDsl
+  operator fun <A : Actor> Scene2dFactoryDescriptor<A>.invoke(
+    placement: @UnsafeVariance Storage.() -> Unit = {},
+    init: A.() -> Unit = {},
+  ): A = this@KWidget.mount(scene2d(build), placement, init)
 }
 
 /**

--- a/scene2d/src/main/kotlin/ktx/scene2d/widget.kt
+++ b/scene2d/src/main/kotlin/ktx/scene2d/widget.kt
@@ -55,7 +55,7 @@ interface KWidget<out Storage> {
   @Scene2dDsl
   operator fun <A : Actor> Scene2dFactoryDescriptor<A>.invoke(
     placement: @UnsafeVariance Storage.() -> Unit = {},
-    init: A.() -> Unit = {},
+    init: (@Scene2dDsl A).() -> Unit = {},
   ): A = this@KWidget.mount(scene2d(build), placement, init)
 }
 

--- a/scene2d/src/test/kotlin/ktx/scene2d/Scene2dFactoryTest.kt
+++ b/scene2d/src/test/kotlin/ktx/scene2d/Scene2dFactoryTest.kt
@@ -53,11 +53,41 @@ class Scene2dFactoryTest : ApplicationTest() {
 
   private class HealthBar(val value: Float) : Actor()
 
+  private val healthBarFactory = scene2dFactory { actor(HealthBar(1f)) }
+
   private inline fun <S> KWidget<S>.healthBar(
     value: Float,
     placement: S.() -> Unit = {},
-    init: HealthBar.() -> Unit = {},
+    init: (@Scene2dDsl HealthBar).() -> Unit = {},
   ): HealthBar = mount(HealthBar(value), placement, init)
+
+  @Test
+  fun `mount accepts isolated custom actor init receiver`() {
+    val init: (@Scene2dDsl HealthBar).() -> Unit = {
+      name = "isolated mount"
+      // KWidget functions such as label() require an explicit outer receiver in this block.
+    }
+
+    val root = scene2d.table {
+      mount(HealthBar(1f), init = init)
+    }
+
+    assertEquals("isolated mount", root.children.first().name)
+  }
+
+  @Test
+  fun `factory accepts isolated custom actor init receiver`() {
+    val init: (@Scene2dDsl HealthBar).() -> Unit = {
+      name = "isolated factory"
+      // KWidget functions such as label() require an explicit outer receiver in this block.
+    }
+
+    val root = scene2d.table {
+      healthBarFactory(init = init)
+    }
+
+    assertEquals("isolated factory", root.children.first().name)
+  }
 
   @Test
   fun `custom actor factory uses mount`() {

--- a/scene2d/src/test/kotlin/ktx/scene2d/Scene2dFactoryTest.kt
+++ b/scene2d/src/test/kotlin/ktx/scene2d/Scene2dFactoryTest.kt
@@ -1,0 +1,73 @@
+package ktx.scene2d
+
+import com.badlogic.gdx.scenes.scene2d.Actor
+import com.badlogic.gdx.scenes.scene2d.ui.Label
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotSame
+import org.junit.Assert.assertSame
+import org.junit.Test
+
+class Scene2dFactoryTest : ApplicationTest() {
+  private val sidePane = scene2dFactory {
+    table {
+      label("Inventory")
+    }
+  }
+
+  @Test
+  fun `factory value can be invoked in root scope and creates fresh actors`() {
+    val first = scene2d { sidePane() }
+    val second = scene2d { sidePane() }
+
+    assertNotSame(first, second)
+    assertEquals("Inventory", (first.children.first() as Label).text.toString())
+    assertEquals("Inventory", (second.children.first() as Label).text.toString())
+  }
+
+  @Test
+  fun `factory trailing init configures actor and placement configures table cell`() {
+    val root = scene2d.table {
+      sidePane(
+        placement = {
+          growY()
+        },
+      ) {
+        label("Extra content")
+      }
+    }
+
+    val pane = root.children.first() as KTableWidget
+    assertEquals(2, pane.children.size)
+    assertEquals("Extra content", (pane.children[1] as Label).text.toString())
+    assertEquals(1, root.getCell(pane).expandY)
+  }
+
+  @Test
+  fun `same factory mounts in table and group scopes`() {
+    val table = scene2d.table { sidePane() }
+    val group = scene2d.stack { sidePane() }
+
+    assertSame(table, (table.children.first() as KTableWidget).parent)
+    assertSame(group, group.children.first().parent)
+  }
+
+  private class HealthBar(val value: Float) : Actor()
+
+  private inline fun <S> KWidget<S>.healthBar(
+    value: Float,
+    placement: S.() -> Unit = {},
+    init: HealthBar.() -> Unit = {},
+  ): HealthBar = mount(HealthBar(value), placement, init)
+
+  @Test
+  fun `custom actor factory uses mount`() {
+    val root = scene2d.stack {
+      healthBar(0.75f) {
+        name = "health"
+      }
+    }
+
+    assertEquals("health", root.children.first().name)
+    assertEquals(0.75f, (root.children.first() as HealthBar).value, TOLERANCE)
+  }
+}


### PR DESCRIPTION
## Summary
- add `mount` with separated placement and actor initialization
- add reusable `Scene2dFactoryDescriptor` recipes and member-extension invocation
- migrate `table` to separated callbacks
- add focused tests and documentation

## Verification
- `JAVA_TOOL_OPTIONS="-Dnet.bytebuddy.experimental=true" ./gradlew :scene2d:check --rerun-tasks`
- focused `Scene2dFactoryTest` passes
- full repository `./gradlew test --rerun-tasks` reached unchanged `app:ProfilingTest` and failed its timing assertions (`0.01207` vs `0.01`); no app files changed

Java 23 emits non-fatal JaCoCo class-version warnings.